### PR TITLE
Add backend test coverage with CI enforcement

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -38,9 +38,11 @@ jobs:
         working-directory: ./backend
         run: go mod download
 
-      - name: Test backend
+      - name: Test backend with coverage
         working-directory: ./backend
-        run: go test ./... -count=1
+        run: |
+          go test ./... -count=1 -p 1
+          bash scripts/check-coverage.sh
 
       - name: Build backend
         working-directory: ./backend

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,14 +1,12 @@
 name: Lint, build and test frontend
 
+# No path filters: branch protection requires this job name (`lint-and-build`)
+# on every PR to production, including backend-only changes.
 on:
   pull_request:
-    paths:
-      - 'frontend/**'
     branches:
       - production
   push:
-    paths:
-      - 'frontend/**'
     branches:
       - production
 
@@ -18,10 +16,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23.9.0'
 
       - name: Install dependencies
         run: npm install

--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+coverage.out
+*.out

--- a/backend/internal/apperrors/errors_test.go
+++ b/backend/internal/apperrors/errors_test.go
@@ -1,0 +1,45 @@
+package apperrors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewAndIsAppError(t *testing.T) {
+	codes := []ErrorCode{
+		EntityNotFoundError,
+		EntityCreateError,
+		EntityUpdateError,
+		EntityDeleteError,
+		ValidationError,
+		UnauthorizedError,
+		ForbiddenError,
+	}
+	for _, code := range codes {
+		err := New(code)
+		if err.Code != code {
+			t.Fatalf("expected code %s, got %s", code, err.Code)
+		}
+		def := errorDefs[code]
+		if err.Message != def.Message || err.StatusCode != def.StatusCode {
+			t.Fatalf("unexpected error fields for %s: %+v", code, err)
+		}
+		ae, ok := IsAppError(err)
+		if !ok || ae != err {
+			t.Fatalf("IsAppError failed for %s", code)
+		}
+	}
+}
+
+func TestIsAppErrorNonAppError(t *testing.T) {
+	if _, ok := IsAppError(errors.New("plain")); ok {
+		t.Fatal("expected false for plain error")
+	}
+}
+
+func TestAppErrorString(t *testing.T) {
+	err := New(UnauthorizedError)
+	if err.Error() == "" {
+		t.Fatal("expected non-empty error string")
+	}
+}

--- a/backend/internal/auth/cookie_test.go
+++ b/backend/internal/auth/cookie_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSetSessionCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+	cfg := CookieConfig{Secure: true, TTL: time.Hour}
+	SetSessionCookie(w, "token-value", cfg)
+
+	res := w.Result()
+	cookies := res.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+	c := cookies[0]
+	if c.Name != SessionCookieName {
+		t.Fatalf("expected cookie name %s, got %s", SessionCookieName, c.Name)
+	}
+	if c.Value != "token-value" {
+		t.Fatalf("expected token-value, got %s", c.Value)
+	}
+	if !c.HttpOnly {
+		t.Fatal("expected HttpOnly")
+	}
+	if !c.Secure {
+		t.Fatal("expected Secure")
+	}
+	if c.Path != "/" {
+		t.Fatalf("expected path /, got %s", c.Path)
+	}
+	if c.MaxAge != 3600 {
+		t.Fatalf("expected MaxAge 3600, got %d", c.MaxAge)
+	}
+}
+
+func TestClearSessionCookie(t *testing.T) {
+	w := httptest.NewRecorder()
+	cfg := CookieConfig{Secure: false, TTL: time.Hour}
+	ClearSessionCookie(w, cfg)
+
+	res := w.Result()
+	c := res.Cookies()[0]
+	if c.Value != "" {
+		t.Fatalf("expected empty value, got %s", c.Value)
+	}
+	if c.MaxAge != -1 {
+		t.Fatalf("expected MaxAge -1, got %d", c.MaxAge)
+	}
+}
+
+func TestSessionTokenFromRequest(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "abc"})
+	token, err := SessionTokenFromRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "abc" {
+		t.Fatalf("expected abc, got %s", token)
+	}
+}
+
+func TestSessionTokenFromRequestMissing(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	if _, err := SessionTokenFromRequest(req); err == nil {
+		t.Fatal("expected error for missing cookie")
+	}
+}

--- a/backend/internal/auth/google.go
+++ b/backend/internal/auth/google.go
@@ -15,6 +15,10 @@ type GoogleIdentity struct {
 	Picture       string
 }
 
+type GoogleTokenVerifier interface {
+	VerifyIDToken(ctx context.Context, rawToken string) (GoogleIdentity, error)
+}
+
 type GoogleVerifier struct {
 	clientID string
 }

--- a/backend/internal/auth/google_integration_test.go
+++ b/backend/internal/auth/google_integration_test.go
@@ -1,0 +1,19 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
+)
+
+func TestGoogleVerifier_InvalidToken(t *testing.T) {
+	verifier := auth.NewGoogleVerifier("test-client-id")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := verifier.VerifyIDToken(ctx, "not-a-real-token")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}

--- a/backend/internal/auth/google_test.go
+++ b/backend/internal/auth/google_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import "testing"
+
+func TestClaimBool(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  bool
+	}{
+		{"bool true", true, true},
+		{"bool false", false, false},
+		{"string true", "true", true},
+		{"string 1", "1", true},
+		{"string false", "false", false},
+		{"nil", nil, false},
+		{"int", 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claimBool(tt.input); got != tt.want {
+				t.Fatalf("claimBool(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestTokenService_IssueParseRoundtrip(t *testing.T) {
+	svc := NewTokenService("secret", time.Hour)
+	user := UserContext{ID: "user-1", Username: "test", Email: "test@example.com"}
+
+	token, expiresAt, err := svc.Issue(user)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+	if expiresAt.Before(time.Now()) {
+		t.Fatal("expected future expiry")
+	}
+
+	claims, err := svc.Parse(token)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if claims.UserID != user.ID || claims.Username != user.Username || claims.Email != user.Email {
+		t.Fatalf("unexpected claims: %+v", claims)
+	}
+}
+
+func TestTokenService_ParseExpired(t *testing.T) {
+	svc := NewTokenService("secret", -time.Hour)
+	token, _, err := svc.Issue(UserContext{ID: "user-1", Username: "test", Email: "test@example.com"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if _, err := svc.Parse(token); err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestTokenService_ParseWrongSecret(t *testing.T) {
+	issuer := NewTokenService("secret-a", time.Hour)
+	parser := NewTokenService("secret-b", time.Hour)
+
+	token, _, err := issuer.Issue(UserContext{ID: "user-1", Username: "test", Email: "test@example.com"})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if _, err := parser.Parse(token); err == nil {
+		t.Fatal("expected error for wrong secret")
+	}
+}
+
+func TestTokenService_ParseBadSigningMethod(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, &Claims{
+		UserID:   "user-1",
+		Username: "test",
+		Email:    "test@example.com",
+	})
+	unsigned, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	svc := NewTokenService("secret", time.Hour)
+	if _, err := svc.Parse(unsigned); err == nil {
+		t.Fatal("expected error for unexpected signing method")
+	}
+}

--- a/backend/internal/auth/main_test.go
+++ b/backend/internal/auth/main_test.go
@@ -1,0 +1,15 @@
+package auth_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	app := testutil.MustInit()
+	code := m.Run()
+	app.Cleanup()
+	os.Exit(code)
+}

--- a/backend/internal/auth/session_auth_test.go
+++ b/backend/internal/auth/session_auth_test.go
@@ -1,0 +1,81 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
+	"github.com/slavo/ChineseLaoshi/backend/internal/repository"
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+func TestSessionAuthenticator_ValidCookie(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	userRepo := repository.NewUserRepository(app.Pool())
+	tokenService := auth.NewTokenService("test-jwt-secret", time.Hour)
+	authenticator := auth.NewSessionAuthenticator(tokenService, userRepo)
+
+	token, _, err := tokenService.Issue(auth.UserContext{
+		ID:       testutil.GetUUID(1),
+		Username: "slavoyar",
+		Email:    testutil.DefaultTestEmail,
+		Provider: "google",
+	})
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+
+	user, err := authenticator.UserFromRequest(req)
+	if err != nil {
+		t.Fatalf("UserFromRequest: %v", err)
+	}
+	if user.Email != testutil.DefaultTestEmail {
+		t.Fatalf("expected %s, got %s", testutil.DefaultTestEmail, user.Email)
+	}
+}
+
+func TestSessionAuthenticator_MissingCookie(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	userRepo := repository.NewUserRepository(app.Pool())
+	tokenService := auth.NewTokenService("test-jwt-secret", time.Hour)
+	authenticator := auth.NewSessionAuthenticator(tokenService, userRepo)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	if _, err := authenticator.UserFromRequest(req); err == nil {
+		t.Fatal("expected error for missing cookie")
+	}
+}
+
+func TestSessionAuthenticator_InvalidToken(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	userRepo := repository.NewUserRepository(app.Pool())
+	tokenService := auth.NewTokenService("test-jwt-secret", time.Hour)
+	authenticator := auth.NewSessionAuthenticator(tokenService, userRepo)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: "not-a-valid-token"})
+
+	if _, err := authenticator.UserFromRequest(req); err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestDefaultUserAuthenticator(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	userRepo := repository.NewUserRepository(app.Pool())
+	authenticator := auth.NewDefaultUserAuthenticator(userRepo, testutil.DefaultTestEmail)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	user, err := authenticator.UserFromRequest(req)
+	if err != nil {
+		t.Fatalf("UserFromRequest: %v", err)
+	}
+	if user.Email != testutil.DefaultTestEmail {
+		t.Fatalf("expected %s, got %s", testutil.DefaultTestEmail, user.Email)
+	}
+}

--- a/backend/internal/auth/session_test.go
+++ b/backend/internal/auth/session_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithUserAndUserFromContext(t *testing.T) {
+	user := UserContext{ID: "1", Username: "test", Email: "a@b.com"}
+	ctx := WithUser(context.Background(), user)
+
+	got, ok := UserFromContext(ctx)
+	if !ok {
+		t.Fatal("expected user in context")
+	}
+	if got != user {
+		t.Fatalf("expected %+v, got %+v", user, got)
+	}
+}
+
+func TestUserFromContextMissing(t *testing.T) {
+	if _, ok := UserFromContext(context.Background()); ok {
+		t.Fatal("expected no user in context")
+	}
+}

--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -1,0 +1,148 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+var testHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+func TestAuth_GoogleLoginInvalidToken(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	body, _ := json.Marshal(map[string]string{"idToken": "invalid-token"})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, app.Server.URL+"/api/auth/google", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:5173")
+	res, err := testHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}
+
+func TestAuth_GoogleLoginMissingToken(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	req, _ := http.NewRequest(http.MethodPost, app.Server.URL+"/api/auth/google", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:5173")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAuth_GoogleLoginOriginRejected(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	body, _ := json.Marshal(map[string]string{"idToken": "token"})
+	req, _ := http.NewRequest(http.MethodPost, app.Server.URL+"/api/auth/google", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://evil.com")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.StatusCode)
+	}
+}
+
+func TestAuth_Logout(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	req, _ := http.NewRequest(http.MethodPost, app.Server.URL+"/api/auth/logout", nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.StatusCode)
+	}
+	cookies := res.Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == auth.SessionCookieName {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected session cookie to be cleared on logout")
+	}
+	if sessionCookie.Value != "" {
+		t.Fatalf("expected empty session cookie value, got %q", sessionCookie.Value)
+	}
+	if sessionCookie.MaxAge != -1 {
+		t.Fatalf("expected MaxAge -1, got %d", sessionCookie.MaxAge)
+	}
+}
+
+func TestAuth_MeUnauthorized(t *testing.T) {
+	app := testutil.SetupStrictAuthApp(t)
+	res, err := http.Get(app.Server.URL + "/api/auth/me")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}
+
+func TestAuth_MeWithSession(t *testing.T) {
+	app := testutil.SetupStrictAuthApp(t)
+	req := app.AuthenticatedRequest(t, http.MethodGet, app.Server.URL+"/api/auth/me", nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if body["email"] != testutil.DefaultTestEmail {
+		t.Fatalf("expected email %s, got %v", testutil.DefaultTestEmail, body["email"])
+	}
+}
+
+func TestGroups_CreateUnauthorized(t *testing.T) {
+	app := testutil.SetupStrictAuthApp(t)
+	body, _ := json.Marshal(map[string]string{"name": "test"})
+	res, err := http.Post(app.Server.URL+"/api/groups", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}

--- a/backend/internal/handler/cards_test.go
+++ b/backend/internal/handler/cards_test.go
@@ -209,3 +209,86 @@ func TestCards_DeleteNotFound(t *testing.T) {
 		t.Fatalf("expected 404, got %d", res.StatusCode)
 	}
 }
+
+func TestCards_GetWriteCards(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	payload := map[string]string{"count": "2"}
+	body, _ := json.Marshal(payload)
+	res, err := http.Post(app.Server.URL+"/api/cards/study/write", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+
+	var cards []map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&cards); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(cards) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(cards))
+	}
+}
+
+func TestCards_GetWriteCardsWithGroup(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	payload := map[string]string{"count": "5", "groupId": testutil.GetUUID(1)}
+	body, _ := json.Marshal(payload)
+	res, err := http.Post(app.Server.URL+"/api/cards/study/write", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+
+	var cards []map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&cards); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(cards) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(cards))
+	}
+}
+
+func TestCards_GetWriteCardsValidation(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	cases := []string{`{}`, `{"count":""}`, `{"count":"5","groupId":"bad"}`}
+	for _, payload := range cases {
+		res, err := http.Post(app.Server.URL+"/api/cards/study/write", "application/json", bytes.NewReader([]byte(payload)))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		res.Body.Close()
+		if res.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400 for %s, got %d", payload, res.StatusCode)
+		}
+	}
+}
+
+func TestCards_CreateUnauthorized(t *testing.T) {
+	app := testutil.SetupStrictAuthApp(t)
+	payload := map[string]any{
+		"groupId": testutil.GetUUID(1),
+		"word": map[string]string{
+			"symbols":       "三",
+			"transcription": "san",
+			"translation":   "three",
+		},
+	}
+	body, _ := json.Marshal(payload)
+	res, err := http.Post(app.Server.URL+"/api/cards", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}

--- a/backend/internal/handler/origin_test.go
+++ b/backend/internal/handler/origin_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestOriginAllowed(t *testing.T) {
+	allowed := []string{"http://localhost:5173", "https://app.example.com"}
+
+	tests := []struct {
+		name   string
+		origin string
+		referer string
+		want   bool
+	}{
+		{"exact origin", "http://localhost:5173", "", true},
+		{"origin trailing slash", "http://localhost:5173/", "", true},
+		{"case insensitive", "HTTP://LOCALHOST:5173", "", true},
+		{"referer fallback", "", "http://localhost:5173/page", true},
+		{"rejected origin", "http://evil.com", "", false},
+		{"missing origin and referer", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/google", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.referer != "" {
+				req.Header.Set("Referer", tt.referer)
+			}
+			if got := requestOriginAllowed(req, allowed); got != tt.want {
+				t.Fatalf("requestOriginAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestOriginAllowedEmptyList(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/google", nil)
+	if !requestOriginAllowed(req, nil) {
+		t.Fatal("expected allowed when list is empty")
+	}
+}

--- a/backend/internal/handler/validate_test.go
+++ b/backend/internal/handler/validate_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/dto"
+)
+
+func TestValidateCreateGroup(t *testing.T) {
+	w := httptest.NewRecorder()
+	if validateCreateGroup(w, &dto.CreateGroup{Name: "ok"}) != true {
+		t.Fatal("expected valid create group")
+	}
+
+	w = httptest.NewRecorder()
+	if validateCreateGroup(w, &dto.CreateGroup{Name: ""}) != false || w.Code != 400 {
+		t.Fatal("expected invalid empty name")
+	}
+}
+
+func TestValidateUpdateGroup(t *testing.T) {
+	validID := "00000000-0000-0000-0000-000000000001"
+	w := httptest.NewRecorder()
+	if validateUpdateGroup(w, &dto.UpdateGroup{ID: validID, Name: "ok"}) != true {
+		t.Fatal("expected valid update group")
+	}
+
+	w = httptest.NewRecorder()
+	if validateUpdateGroup(w, &dto.UpdateGroup{ID: "bad", Name: "ok"}) != false {
+		t.Fatal("expected invalid id")
+	}
+
+	w = httptest.NewRecorder()
+	if validateUpdateGroup(w, &dto.UpdateGroup{ID: validID, Name: ""}) != false {
+		t.Fatal("expected invalid empty name")
+	}
+}
+
+func TestValidateCreateCard(t *testing.T) {
+	validID := "00000000-0000-0000-0000-000000000001"
+	symbols, transcription, translation := "一", "yi", "one"
+	wordID := validID
+
+	w := httptest.NewRecorder()
+	if validateCreateCard(w, &dto.CreateCard{
+		GroupID: validID,
+		Word:    dto.CreateCardWord{Symbols: &symbols, Transcription: &transcription, Translation: &translation},
+	}) != true {
+		t.Fatal("expected valid new word card")
+	}
+
+	w = httptest.NewRecorder()
+	if validateCreateCard(w, &dto.CreateCard{GroupID: validID, Word: dto.CreateCardWord{ID: &wordID}}) != true {
+		t.Fatal("expected valid existing word card")
+	}
+
+	w = httptest.NewRecorder()
+	if validateCreateCard(w, &dto.CreateCard{GroupID: "bad", Word: dto.CreateCardWord{ID: &wordID}}) != false {
+		t.Fatal("expected invalid group id")
+	}
+
+	w = httptest.NewRecorder()
+	if validateCreateCard(w, &dto.CreateCard{GroupID: validID, Word: dto.CreateCardWord{}}) != false {
+		t.Fatal("expected invalid word")
+	}
+}
+
+func TestValidateUpdateCardWord(t *testing.T) {
+	validID := "00000000-0000-0000-0000-000000000001"
+	w := httptest.NewRecorder()
+	if validateUpdateCardWord(w, &dto.UpdateCardWord{
+		ID: validID,
+		Word: dto.Word{ID: validID, Symbols: "一", Transcription: "yi", Translation: "one"},
+	}) != true {
+		t.Fatal("expected valid update card word")
+	}
+
+	w = httptest.NewRecorder()
+	if validateUpdateCardWord(w, &dto.UpdateCardWord{ID: "bad", Word: dto.Word{ID: validID}}) != false {
+		t.Fatal("expected invalid card id")
+	}
+}
+
+func TestValidateUpdateCardStats(t *testing.T) {
+	validID := "00000000-0000-0000-0000-000000000001"
+	w := httptest.NewRecorder()
+	if validateUpdateCardStats(w, &dto.UpdateCardStats{ID: validID, Guessed: true}) != true {
+		t.Fatal("expected valid stats update")
+	}
+
+	w = httptest.NewRecorder()
+	if validateUpdateCardStats(w, &dto.UpdateCardStats{ID: "bad", Guessed: true}) != false {
+		t.Fatal("expected invalid id")
+	}
+}
+
+func TestValidateGetWriteCard(t *testing.T) {
+	validID := "00000000-0000-0000-0000-000000000001"
+	w := httptest.NewRecorder()
+	if validateGetWriteCard(w, &dto.GetWriteCard{Count: "5"}) != true {
+		t.Fatal("expected valid write card request")
+	}
+
+	w = httptest.NewRecorder()
+	groupID := validID
+	if validateGetWriteCard(w, &dto.GetWriteCard{Count: "5", GroupID: &groupID}) != true {
+		t.Fatal("expected valid write card with group")
+	}
+
+	w = httptest.NewRecorder()
+	if validateGetWriteCard(w, &dto.GetWriteCard{Count: ""}) != false {
+		t.Fatal("expected invalid empty count")
+	}
+
+	w = httptest.NewRecorder()
+	bad := "bad"
+	if validateGetWriteCard(w, &dto.GetWriteCard{Count: "5", GroupID: &bad}) != false {
+		t.Fatal("expected invalid group id")
+	}
+}
+
+func TestIsUUID(t *testing.T) {
+	if !isUUID("00000000-0000-0000-0000-000000000001") {
+		t.Fatal("expected valid uuid")
+	}
+	if isUUID("not-a-uuid") {
+		t.Fatal("expected invalid uuid")
+	}
+}

--- a/backend/internal/middleware/middleware_test.go
+++ b/backend/internal/middleware/middleware_test.go
@@ -1,0 +1,125 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/slavo/ChineseLaoshi/backend/internal/apperrors"
+	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
+)
+
+type mockAuthenticator struct {
+	user auth.UserContext
+	err  error
+}
+
+func (m mockAuthenticator) UserFromRequest(r *http.Request) (auth.UserContext, error) {
+	if m.err != nil {
+		return auth.UserContext{}, m.err
+	}
+	return m.user, nil
+}
+
+func TestRequireAuthRejectsMissingUser(t *testing.T) {
+	handler := RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/me", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestOptionalAuthAttachesUser(t *testing.T) {
+	user := auth.UserContext{ID: "1", Username: "test", Email: "a@b.com"}
+	mw := OptionalAuth(mockAuthenticator{user: user})
+	called := false
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		got, ok := auth.UserFromContext(r.Context())
+		if !ok || got.ID != user.ID {
+			t.Fatalf("expected user in context, got %+v ok=%v", got, ok)
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !called {
+		t.Fatal("expected handler to be called")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRecovererCatchesPanic(t *testing.T) {
+	handler := Recoverer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestWriteErrorAppError(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeError(w, apperrors.New(apperrors.ForbiddenError))
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	var body apperrors.AppError
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Code != apperrors.ForbiddenError {
+		t.Fatalf("expected forbidden code, got %s", body.Code)
+	}
+}
+
+func TestWriteErrorNoRows(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeError(w, pgx.ErrNoRows)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestWriteErrorGeneric(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeError(w, errors.New("unexpected"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestUserFromContextMiddleware(t *testing.T) {
+	ctx := auth.WithUser(context.Background(), auth.UserContext{ID: "1"})
+	user, err := UserFromContext(ctx)
+	if err != nil || user.ID != "1" {
+		t.Fatalf("expected user, got %+v err=%v", user, err)
+	}
+
+	if _, err := UserFromContext(context.Background()); err == nil {
+		t.Fatal("expected unauthorized without user")
+	}
+}

--- a/backend/internal/repository/main_test.go
+++ b/backend/internal/repository/main_test.go
@@ -1,0 +1,468 @@
+package repository_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/slavo/ChineseLaoshi/backend/internal/apperrors"
+	"github.com/slavo/ChineseLaoshi/backend/internal/dto"
+	"github.com/slavo/ChineseLaoshi/backend/internal/repository"
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	app := testutil.MustInit()
+	code := m.Run()
+	app.Cleanup()
+	os.Exit(code)
+}
+
+func setupRepos(t *testing.T) (*repository.UserRepository, *repository.GroupRepository, *repository.CardRepository, *repository.WordRepository, *repository.CloneRepository, *pgxpool.Pool, string) {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	userID := testutil.GetUUID(1)
+	return repository.NewUserRepository(app.Pool()),
+		repository.NewGroupRepository(app.Pool()),
+		repository.NewCardRepository(app.Pool()),
+		repository.NewWordRepository(app.Pool()),
+		repository.NewCloneRepository(app.Pool()),
+		app.Pool(),
+		userID
+}
+
+func TestUserRepository_GetByEmail(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	user, err := users.GetByEmail(context.Background(), testutil.DefaultTestEmail)
+	if err != nil {
+		t.Fatalf("get by email: %v", err)
+	}
+	if user.Email != testutil.DefaultTestEmail {
+		t.Fatalf("unexpected email: %s", user.Email)
+	}
+}
+
+func TestUserRepository_GetByProviderSubject(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	user, err := users.GetByProviderSubject(context.Background(), "google", "test-subject-1")
+	if err != nil {
+		t.Fatalf("get by provider: %v", err)
+	}
+	if user.Email != testutil.DefaultTestEmail {
+		t.Fatalf("unexpected user: %+v", user)
+	}
+}
+
+func TestUserRepository_GetByIDNotFound(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	_, err := users.GetByID(context.Background(), testutil.GetUUID(404))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestUserRepository_CreateSSOUser(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	user, err := users.CreateSSOUser(context.Background(), "NewUser", "sso-new@example.com", "google", "sso-subject-new", "http://pic")
+	if err != nil {
+		t.Fatalf("create sso user: %v", err)
+	}
+	if user.Email != "sso-new@example.com" {
+		t.Fatalf("unexpected user: %+v", user)
+	}
+}
+
+func TestGroupRepository_CRUD(t *testing.T) {
+	_, groups, _, _, _, _, userID := setupRepos(t)
+	ctx := context.Background()
+
+	created, err := groups.CreateGroup(ctx, dto.CreateGroup{Name: "Repo Group"}, userID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	list, err := groups.GetGroupsByUserID(ctx, userID)
+	if err != nil || len(list) < 4 {
+		t.Fatalf("list groups: %v len=%d", err, len(list))
+	}
+
+	updated, err := groups.UpdateGroup(ctx, dto.UpdateGroup{ID: created.ID, Name: "Renamed"}, userID)
+	if err != nil || updated.Name != "Renamed" {
+		t.Fatalf("update: %v %+v", err, updated)
+	}
+
+	if err := groups.AssertOwnedByUser(ctx, created.ID, userID); err != nil {
+		t.Fatalf("assert owned: %v", err)
+	}
+
+	if err := groups.AssertOwnedByUser(ctx, created.ID, testutil.GetUUID(404)); err == nil {
+		t.Fatal("expected not owned error")
+	}
+}
+
+func TestCardRepository_GetCardsByGroupID(t *testing.T) {
+	_, _, cards, _, _, _, userID := setupRepos(t)
+	list, err := cards.GetCardsByGroupID(context.Background(), testutil.GetUUID(1), userID)
+	if err != nil {
+		t.Fatalf("get cards: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(list))
+	}
+}
+
+func TestCardRepository_GetWriteCards(t *testing.T) {
+	_, _, cards, _, _, _, userID := setupRepos(t)
+	list, err := cards.GetWriteCards(context.Background(), 2, userID, nil)
+	if err != nil {
+		t.Fatalf("get write cards: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(list))
+	}
+}
+
+func TestCardRepository_AssertOwnedByUser(t *testing.T) {
+	_, _, cards, _, _, _, userID := setupRepos(t)
+	if err := cards.AssertOwnedByUser(context.Background(), testutil.GetUUID(1), userID); err != nil {
+		t.Fatalf("assert owned: %v", err)
+	}
+	if err := cards.AssertOwnedByUser(context.Background(), testutil.GetUUID(404), userID); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestWordRepository_SearchWord(t *testing.T) {
+	_, _, _, words, _, _, _ := setupRepos(t)
+	results, err := words.SearchWord(context.Background(), "собака")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected matches")
+	}
+}
+
+func TestWordRepository_SearchWordEmpty(t *testing.T) {
+	_, _, _, words, _, _, _ := setupRepos(t)
+	results, err := words.SearchWord(context.Background(), "")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty, got %d", len(results))
+	}
+}
+
+func TestWordRepository_GetWordsInOtherGroups(t *testing.T) {
+	_, _, _, words, _, _, _ := setupRepos(t)
+	result, err := words.GetWordsInOtherGroups(context.Background(), testutil.GetUUID(1), []string{testutil.GetUUID(1)})
+	if err != nil {
+		t.Fatalf("get words in other groups: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected no words in other groups, got %d", len(result))
+	}
+}
+
+func TestCloneRepository_CountGroupsAndClone(t *testing.T) {
+	users, _, _, _, cloner, _, _ := setupRepos(t)
+	ctx := context.Background()
+
+	sourceUserID := testutil.GetUUID(1)
+
+	newUser, err := users.CreateSSOUser(ctx, "CloneTarget", "clone-target@example.com", "google", "clone-target-sub", "")
+	if err != nil {
+		t.Fatalf("create target user: %v", err)
+	}
+
+	count, err := cloner.CountGroups(ctx, newUser.ID)
+	if err != nil || count != 0 {
+		t.Fatalf("count groups: %v count=%d", err, count)
+	}
+
+	if err := cloner.CloneUserContent(ctx, sourceUserID, newUser.ID); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	count, err = cloner.CountGroups(ctx, newUser.ID)
+	if err != nil || count == 0 {
+		t.Fatalf("expected cloned groups, count=%d err=%v", count, err)
+	}
+}
+
+func TestGroupRepository_DeleteGroup(t *testing.T) {
+	_, groups, _, _, _, _, userID := setupRepos(t)
+	ctx := context.Background()
+	created, err := groups.CreateGroup(ctx, dto.CreateGroup{Name: "Delete Me"}, userID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := groups.DeleteGroup(ctx, created.ID, userID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestGroupRepository_IncrementDecrementWordCount(t *testing.T) {
+	_, groups, _, _, _, pool, userID := setupRepos(t)
+	ctx := context.Background()
+	groupID := testutil.GetUUID(3)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := groups.IncrementWordCount(ctx, tx, groupID); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	if err := groups.DecrementWordCount(ctx, tx, groupID); err != nil {
+		t.Fatalf("decrement: %v", err)
+	}
+	_ = userID
+}
+
+func TestCardRepository_CreateUpdateDelete(t *testing.T) {
+	_, groups, cards, words, _, pool, userID := setupRepos(t)
+	ctx := context.Background()
+	groupID := testutil.GetUUID(3)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	word, err := words.CreateWord(ctx, tx, dto.CreateWord{
+		Symbols: "六", Transcription: "liu", Translation: "six",
+	})
+	if err != nil {
+		t.Fatalf("create word: %v", err)
+	}
+
+	card, err := cards.CreateCard(ctx, tx, groupID, word.ID)
+	if err != nil {
+		t.Fatalf("create card: %v", err)
+	}
+
+	if err := groups.IncrementWordCount(ctx, tx, groupID); err != nil {
+		t.Fatalf("increment word count: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	row, err := cards.GetCardByID(ctx, card.ID)
+	if err != nil {
+		t.Fatalf("get card: %v", err)
+	}
+	if row.WordID != word.ID {
+		t.Fatalf("unexpected word id: %s", row.WordID)
+	}
+
+	count, err := cards.GetCardsCount(ctx, word.ID)
+	if err != nil || count != 1 {
+		t.Fatalf("cards count: %v %d", err, count)
+	}
+
+	progress := 0.5
+	updated, err := cards.UpdateCard(ctx, nil, repository.UpdateCardInput{
+		ID: card.ID, Progress: &progress,
+	})
+	if err != nil || updated.Progress != 0.5 {
+		t.Fatalf("update card: %v %+v", err, updated)
+	}
+
+	tx, err = pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	if err := cards.DeleteCard(ctx, tx, card.ID); err != nil {
+		t.Fatalf("delete card: %v", err)
+	}
+	if err := words.DeleteWord(ctx, tx, word.ID); err != nil {
+		t.Fatalf("delete word: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit delete: %v", err)
+	}
+	_ = userID
+}
+
+func TestWordRepository_UpdateAndDeleteWords(t *testing.T) {
+	_, _, _, words, _, pool, _ := setupRepos(t)
+	ctx := context.Background()
+
+	updated, err := words.UpdateWord(ctx, dto.Word{
+		ID: testutil.GetUUID(1), Symbols: "一", Transcription: "yi", Translation: "one",
+	})
+	if err != nil || updated.Translation != "one" {
+		t.Fatalf("update word: %v %+v", err, updated)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tempWord, err := words.CreateWord(ctx, tx, dto.CreateWord{
+		Symbols: "七", Transcription: "qi", Translation: "seven",
+	})
+	if err != nil {
+		t.Fatalf("create temp word: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if err := words.DeleteWords(ctx, []string{tempWord.ID}); err != nil {
+		t.Fatalf("delete words: %v", err)
+	}
+}
+
+func TestCardRepository_DeleteCardByGroupID(t *testing.T) {
+	_, groups, cards, _, _, _, userID := setupRepos(t)
+	ctx := context.Background()
+
+	created, err := groups.CreateGroup(ctx, dto.CreateGroup{Name: "Temp"}, userID)
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := cards.DeleteCardByGroupID(ctx, created.ID); err != nil {
+		t.Fatalf("delete cards by group: %v", err)
+	}
+	if err := groups.DeleteGroup(ctx, created.ID, userID); err != nil {
+		t.Fatalf("delete group: %v", err)
+	}
+}
+
+func TestCardRepository_GetCardByIDNotFound(t *testing.T) {
+	_, _, cards, _, _, _, _ := setupRepos(t)
+	_, err := cards.GetCardByID(context.Background(), testutil.GetUUID(404))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardRepository_DeleteCardNotFound(t *testing.T) {
+	_, _, cards, _, _, pool, _ := setupRepos(t)
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	if err := cards.DeleteCard(ctx, tx, testutil.GetUUID(404)); err == nil {
+		t.Fatal("expected error deleting missing card")
+	}
+}
+
+func TestGroupRepository_UpdateGroupNotFound(t *testing.T) {
+	_, groups, _, _, _, _, userID := setupRepos(t)
+	_, err := groups.UpdateGroup(context.Background(), dto.UpdateGroup{
+		ID: testutil.GetUUID(404), Name: "missing",
+	}, userID)
+	if err == nil {
+		t.Fatal("expected error updating missing group")
+	}
+}
+
+func TestUserRepository_GetByEmailNotFound(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	_, err := users.GetByEmail(context.Background(), "missing@example.com")
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestUserRepository_DuplicateUsername(t *testing.T) {
+	users, _, _, _, _, _, _ := setupRepos(t)
+	ctx := context.Background()
+	first, err := users.CreateSSOUser(ctx, "SameName", "first@example.com", "google", "dup-sub-1", "")
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	second, err := users.CreateSSOUser(ctx, "SameName", "second@example.com", "google", "dup-sub-2", "")
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+	if first.Username == second.Username {
+		t.Fatalf("expected unique usernames, both %s", first.Username)
+	}
+}
+
+func TestCardRepository_GetWriteCardsWithGroup(t *testing.T) {
+	_, _, cards, _, _, _, userID := setupRepos(t)
+	groupID := testutil.GetUUID(1)
+	list, err := cards.GetWriteCards(context.Background(), 5, userID, &groupID)
+	if err != nil {
+		t.Fatalf("get write cards: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(list))
+	}
+}
+
+func TestWordRepository_GetWordsInOtherGroupsWithSharedWord(t *testing.T) {
+	_, _, cards, words, _, pool, userID := setupRepos(t)
+	ctx := context.Background()
+	wordID := testutil.GetUUID(1)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO "Card" (id, "groupId", "wordId", "updatedAt")
+		VALUES ($1, $2, $3, NOW())
+	`, testutil.GetUUID(97), testutil.GetUUID(2), wordID)
+	if err != nil {
+		t.Fatalf("insert shared card: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	shared, err := words.GetWordsInOtherGroups(ctx, testutil.GetUUID(2), []string{wordID})
+	if err != nil {
+		t.Fatalf("shared words: %v", err)
+	}
+	if len(shared) == 0 {
+		t.Fatal("expected word shared with another group")
+	}
+	_ = cards
+	_ = userID
+}
+
+func TestGroupRepository_DeleteGroupNotFound(t *testing.T) {
+	_, groups, _, _, _, _, userID := setupRepos(t)
+	err := groups.DeleteGroup(context.Background(), testutil.GetUUID(404), userID)
+	if err == nil {
+		t.Fatal("expected error deleting missing group")
+	}
+}
+
+func TestCardRepository_UpdateCardWithTx(t *testing.T) {
+	_, _, cards, _, _, pool, _ := setupRepos(t)
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	showCount := 5
+	updated, err := cards.UpdateCard(ctx, tx, repository.UpdateCardInput{
+		ID: testutil.GetUUID(1), ShowCount: &showCount,
+	})
+	if err != nil || updated.ShowCount != 5 {
+		t.Fatalf("update with tx: %v %+v", err, updated)
+	}
+}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -16,7 +16,7 @@ const googleProvider = "google"
 type AuthService struct {
 	users    *repository.UserRepository
 	cloner   *repository.CloneRepository
-	google   *auth.GoogleVerifier
+	google   auth.GoogleTokenVerifier
 	tokens   *auth.TokenService
 	template string // template user email for lookup fallback
 }
@@ -24,7 +24,7 @@ type AuthService struct {
 func NewAuthService(
 	users *repository.UserRepository,
 	cloner *repository.CloneRepository,
-	google *auth.GoogleVerifier,
+	google auth.GoogleTokenVerifier,
 	tokens *auth.TokenService,
 	templateEmail string,
 ) *AuthService {

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -1,0 +1,247 @@
+package service_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/apperrors"
+	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
+	"github.com/slavo/ChineseLaoshi/backend/internal/config"
+	"github.com/slavo/ChineseLaoshi/backend/internal/dto"
+	"github.com/slavo/ChineseLaoshi/backend/internal/repository"
+	"github.com/slavo/ChineseLaoshi/backend/internal/service"
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	app := testutil.MustInit()
+	code := m.Run()
+	app.Cleanup()
+	os.Exit(code)
+}
+
+type fakeGoogleVerifier struct {
+	identity auth.GoogleIdentity
+	err      error
+}
+
+func (f fakeGoogleVerifier) VerifyIDToken(ctx context.Context, rawToken string) (auth.GoogleIdentity, error) {
+	if f.err != nil {
+		return auth.GoogleIdentity{}, f.err
+	}
+	return f.identity, nil
+}
+
+func newAuthService(t *testing.T, google auth.GoogleTokenVerifier) *service.AuthService {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	userRepo := repository.NewUserRepository(app.Pool())
+	cloneRepo := repository.NewCloneRepository(app.Pool())
+	tokenService := auth.NewTokenService("test-jwt-secret", config.DefaultSessionTTL)
+	return service.NewAuthService(userRepo, cloneRepo, google, tokenService, config.DefaultTemplateEmail)
+}
+
+func TestAuthService_LoginWithGoogleInvalidToken(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{err: context.Canceled})
+	_, _, err := svc.LoginWithGoogle(context.Background(), "bad")
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.UnauthorizedError {
+		t.Fatalf("expected unauthorized, got %v", err)
+	}
+}
+
+func TestAuthService_LoginWithGoogleUnverifiedEmail(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{identity: auth.GoogleIdentity{
+		Subject: "sub-1", Email: "new@example.com", EmailVerified: false,
+	}})
+	_, _, err := svc.LoginWithGoogle(context.Background(), "token")
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.ForbiddenError {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+}
+
+func TestAuthService_LoginWithGoogleNewUser(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{identity: auth.GoogleIdentity{
+		Subject: "new-google-subject", Email: "brandnew@example.com", EmailVerified: true, Name: "Brand New",
+	}})
+	user, token, err := svc.LoginWithGoogle(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if user.Email != "brandnew@example.com" || token == "" {
+		t.Fatalf("unexpected login result: %+v token=%q", user, token)
+	}
+}
+
+func TestAuthService_LoginWithGoogleExistingUser(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{identity: auth.GoogleIdentity{
+		Subject: "test-subject-1", Email: testutil.DefaultTestEmail, EmailVerified: true, Name: "slavoyar",
+	}})
+	user, token, err := svc.LoginWithGoogle(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if user.Email != testutil.DefaultTestEmail || token == "" {
+		t.Fatalf("unexpected login result: %+v", user)
+	}
+}
+
+func TestAuthService_LoginWithGoogleEmptyNameUsesEmailPrefix(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{identity: auth.GoogleIdentity{
+		Subject: "empty-name-subject", Email: "prefix@example.com", EmailVerified: true, Name: "  ",
+	}})
+	user, _, err := svc.LoginWithGoogle(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if user.Name != "prefix" {
+		t.Fatalf("expected name prefix, got %s", user.Name)
+	}
+}
+
+func TestAuthService_LoginEnsuresStarterContent(t *testing.T) {
+	app := testutil.SetupTestApp(t)
+	users := repository.NewUserRepository(app.Pool())
+	cloneRepo := repository.NewCloneRepository(app.Pool())
+	tokenService := auth.NewTokenService("test-jwt-secret", config.DefaultSessionTTL)
+	google := fakeGoogleVerifier{identity: auth.GoogleIdentity{
+		Subject: "no-groups-subject", Email: "nostarter@example.com", EmailVerified: true, Name: "No Starter",
+	}}
+	svc := service.NewAuthService(users, cloneRepo, google, tokenService, config.DefaultTemplateEmail)
+
+	ctx := context.Background()
+	user, err := users.CreateSSOUser(ctx, "nostarter", "nostarter@example.com", "google", "no-groups-subject", "")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	count, err := cloneRepo.CountGroups(ctx, user.ID)
+	if err != nil || count != 0 {
+		t.Fatalf("expected 0 groups before login, got %d err=%v", count, err)
+	}
+
+	_, _, err = svc.LoginWithGoogle(ctx, "token")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	count, err = cloneRepo.CountGroups(ctx, user.ID)
+	if err != nil || count == 0 {
+		t.Fatalf("expected starter groups after login, got %d err=%v", count, err)
+	}
+}
+
+func TestAuthService_Me(t *testing.T) {
+	svc := newAuthService(t, fakeGoogleVerifier{})
+	dto := svc.Me(context.Background(), auth.UserContext{
+		ID: "1", Username: "test", Email: "a@b.com", AvatarURL: "pic", Provider: "google",
+	})
+	if dto.ID != "1" || dto.Name != "test" || dto.Email != "a@b.com" {
+		t.Fatalf("unexpected dto: %+v", dto)
+	}
+}
+
+func setupGroupService(t *testing.T) (*service.GroupService, string) {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	groupRepo := repository.NewGroupRepository(app.Pool())
+	cardRepo := repository.NewCardRepository(app.Pool())
+	wordRepo := repository.NewWordRepository(app.Pool())
+	return service.NewGroupService(app.Pool(), cardRepo, groupRepo, wordRepo), testutil.GetUUID(1)
+}
+
+func TestGroupService_GetGroupsByUserID(t *testing.T) {
+	svc, userID := setupGroupService(t)
+	groups, err := svc.GetGroupsByUserID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("get groups: %v", err)
+	}
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+}
+
+func TestGroupService_CreateGroup(t *testing.T) {
+	svc, userID := setupGroupService(t)
+	group, err := svc.CreateGroup(context.Background(), dto.CreateGroup{Name: "New Group"}, userID)
+	if err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if group.Name != "New Group" {
+		t.Fatalf("expected New Group, got %s", group.Name)
+	}
+}
+
+func TestGroupService_UpdateGroupNotFound(t *testing.T) {
+	svc, userID := setupGroupService(t)
+	_, err := svc.UpdateGroup(context.Background(), dto.UpdateGroup{ID: testutil.GetUUID(404), Name: "x"}, userID)
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func setupCardService(t *testing.T) *service.CardService {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	groupRepo := repository.NewGroupRepository(app.Pool())
+	cardRepo := repository.NewCardRepository(app.Pool())
+	wordRepo := repository.NewWordRepository(app.Pool())
+	return service.NewCardService(app.Pool(), cardRepo, groupRepo, wordRepo)
+}
+
+func TestCardService_GetWriteCardsInvalidCount(t *testing.T) {
+	svc := setupCardService(t)
+	_, err := svc.GetWriteCards(context.Background(), dto.GetWriteCard{Count: "abc"}, testutil.GetUUID(1))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.ValidationError {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestCardService_GetWriteCards(t *testing.T) {
+	svc := setupCardService(t)
+	cards, err := svc.GetWriteCards(context.Background(), dto.GetWriteCard{Count: "2"}, testutil.GetUUID(1))
+	if err != nil {
+		t.Fatalf("get write cards: %v", err)
+	}
+	if len(cards) != 2 {
+		t.Fatalf("expected 2 cards, got %d", len(cards))
+	}
+}
+
+func TestCardService_UpdateCardStats(t *testing.T) {
+	svc := setupCardService(t)
+	err := svc.UpdateCardStats(context.Background(), dto.UpdateCardStats{ID: testutil.GetUUID(1), Guessed: true}, testutil.GetUUID(1))
+	if err != nil {
+		t.Fatalf("update stats: %v", err)
+	}
+}
+
+func setupWordService(t *testing.T) *service.WordService {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	return service.NewWordService(repository.NewWordRepository(app.Pool()))
+}
+
+func TestWordService_Search(t *testing.T) {
+	svc := setupWordService(t)
+	words, err := svc.Search(context.Background(), "один")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(words) == 0 {
+		t.Fatal("expected at least one word")
+	}
+}
+
+func TestWordService_SearchEmpty(t *testing.T) {
+	svc := setupWordService(t)
+	words, err := svc.Search(context.Background(), "")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(words) != 0 {
+		t.Fatalf("expected empty result, got %d", len(words))
+	}
+}

--- a/backend/internal/service/card_group_test.go
+++ b/backend/internal/service/card_group_test.go
@@ -1,0 +1,309 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/slavo/ChineseLaoshi/backend/internal/apperrors"
+	"github.com/slavo/ChineseLaoshi/backend/internal/dto"
+	"github.com/slavo/ChineseLaoshi/backend/internal/repository"
+	"github.com/slavo/ChineseLaoshi/backend/internal/service"
+	"github.com/slavo/ChineseLaoshi/backend/internal/testutil"
+)
+
+func setupFullServices(t *testing.T) (*service.GroupService, *service.CardService, string) {
+	t.Helper()
+	app := testutil.SetupTestApp(t)
+	groupRepo := repository.NewGroupRepository(app.Pool())
+	cardRepo := repository.NewCardRepository(app.Pool())
+	wordRepo := repository.NewWordRepository(app.Pool())
+	userID := testutil.GetUUID(1)
+	groupSvc := service.NewGroupService(app.Pool(), cardRepo, groupRepo, wordRepo)
+	cardSvc := service.NewCardService(app.Pool(), cardRepo, groupRepo, wordRepo)
+	return groupSvc, cardSvc, userID
+}
+
+func TestGroupService_UpdateGroup(t *testing.T) {
+	svc, _, userID := setupFullServices(t)
+	group, err := svc.CreateGroup(context.Background(), dto.CreateGroup{Name: "To Update"}, userID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	updated, err := svc.UpdateGroup(context.Background(), dto.UpdateGroup{ID: group.ID, Name: "Updated"}, userID)
+	if err != nil || updated.Name != "Updated" {
+		t.Fatalf("update: %v %+v", err, updated)
+	}
+}
+
+func TestGroupService_DeleteGroup(t *testing.T) {
+	svc, _, userID := setupFullServices(t)
+	group, err := svc.CreateGroup(context.Background(), dto.CreateGroup{Name: "To Delete"}, userID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := svc.DeleteGroup(context.Background(), group.ID, userID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestGroupService_DeleteGroupWithCards(t *testing.T) {
+	groupSvc, cardSvc, userID := setupFullServices(t)
+	symbols, transcription, translation := "五", "wu", "five"
+	card, err := cardSvc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(3),
+		Word: dto.CreateCardWord{
+			Symbols:       &symbols,
+			Transcription: &transcription,
+			Translation:   &translation,
+		},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create card: %v", err)
+	}
+	groupID := card.GroupID
+	if err := groupSvc.DeleteGroup(context.Background(), groupID, userID); err != nil {
+		t.Fatalf("delete group: %v", err)
+	}
+}
+
+func TestCardService_CreateCardWithNewWord(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	symbols, transcription, translation := "四", "si", "four"
+	card, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(1),
+		Word: dto.CreateCardWord{
+			Symbols:       &symbols,
+			Transcription: &transcription,
+			Translation:   &translation,
+		},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create card: %v", err)
+	}
+	if card.Word.Symbols != "四" {
+		t.Fatalf("unexpected card: %+v", card)
+	}
+}
+
+func TestCardService_CreateCardWithExistingWord(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	wordID := testutil.GetUUID(1)
+	card, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(1),
+		Word:    dto.CreateCardWord{ID: &wordID},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create card: %v", err)
+	}
+	if card.Word.ID != wordID {
+		t.Fatalf("unexpected word id: %s", card.Word.ID)
+	}
+}
+
+func TestCardService_DeleteCard(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	if err := svc.DeleteCard(context.Background(), testutil.GetUUID(3), userID); err != nil {
+		t.Fatalf("delete card: %v", err)
+	}
+}
+
+func TestCardService_UpdateCard(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	err := svc.UpdateCard(context.Background(), dto.UpdateCardWord{
+		ID:   testutil.GetUUID(1),
+		Word: dto.Word{ID: testutil.GetUUID(1), Symbols: "一", Transcription: "yi", Translation: "one"},
+	}, userID)
+	if err != nil {
+		t.Fatalf("update card: %v", err)
+	}
+}
+
+func TestCardService_GetCardsByGroupNotOwned(t *testing.T) {
+	_, svc, _ := setupFullServices(t)
+	_, err := svc.GetCardsByGroupID(context.Background(), testutil.GetUUID(1), testutil.GetUUID(404))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardService_CreateCardValidationError(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	_, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(1),
+		Word:    dto.CreateCardWord{},
+	}, userID)
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.ValidationError {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestCardService_UpdateCardStatsWrongGuess(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	err := svc.UpdateCardStats(context.Background(), dto.UpdateCardStats{
+		ID: testutil.GetUUID(2), Guessed: false,
+	}, userID)
+	if err != nil {
+		t.Fatalf("update stats: %v", err)
+	}
+}
+
+func TestCardService_UpdateCardSharedWord(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	wordID := testutil.GetUUID(1)
+	_, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(2),
+		Word:    dto.CreateCardWord{ID: &wordID},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create shared word card: %v", err)
+	}
+	err = svc.UpdateCard(context.Background(), dto.UpdateCardWord{
+		ID:   testutil.GetUUID(1),
+		Word: dto.Word{ID: wordID, Symbols: "一", Transcription: "yi", Translation: "one updated"},
+	}, userID)
+	if err != nil {
+		t.Fatalf("update shared word card: %v", err)
+	}
+}
+
+func TestGroupService_DeleteGroupNotFound(t *testing.T) {
+	svc, _, userID := setupFullServices(t)
+	err := svc.DeleteGroup(context.Background(), testutil.GetUUID(404), userID)
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardService_DeleteCardNotFound(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	err := svc.DeleteCard(context.Background(), testutil.GetUUID(404), userID)
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardService_UpdateCardEmptyWordID(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	err := svc.UpdateCard(context.Background(), dto.UpdateCardWord{
+		ID:   testutil.GetUUID(1),
+		Word: dto.Word{Symbols: "一", Transcription: "yi", Translation: "one"},
+	}, userID)
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityUpdateError {
+		t.Fatalf("expected update error, got %v", err)
+	}
+}
+
+func TestGroupService_DeleteGroupWithSharedWord(t *testing.T) {
+	groupSvc, cardSvc, userID := setupFullServices(t)
+	wordID := testutil.GetUUID(1)
+	_, err := cardSvc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(2),
+		Word:    dto.CreateCardWord{ID: &wordID},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create shared card: %v", err)
+	}
+	if err := groupSvc.DeleteGroup(context.Background(), testutil.GetUUID(1), userID); err != nil {
+		t.Fatalf("delete group with shared word: %v", err)
+	}
+}
+
+func TestCardService_GetWriteCardsWithGroupFilter(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	groupID := testutil.GetUUID(1)
+	cards, err := svc.GetWriteCards(context.Background(), dto.GetWriteCard{Count: "5", GroupID: &groupID}, userID)
+	if err != nil {
+		t.Fatalf("get write cards: %v", err)
+	}
+	if len(cards) != 2 {
+		t.Fatalf("expected 2 cards in group, got %d", len(cards))
+	}
+}
+
+func TestCardService_UpdateCardStatsWinStreak(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	for i := 0; i < 2; i++ {
+		if err := svc.UpdateCardStats(context.Background(), dto.UpdateCardStats{
+			ID: testutil.GetUUID(1), Guessed: true,
+		}, userID); err != nil {
+			t.Fatalf("update stats iteration %d: %v", i, err)
+		}
+	}
+}
+
+func TestCardService_CreateCardGroupNotOwned(t *testing.T) {
+	_, svc, _ := setupFullServices(t)
+	symbols, transcription, translation := "八", "ba", "eight"
+	_, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(404),
+		Word: dto.CreateCardWord{
+			Symbols: &symbols, Transcription: &transcription, Translation: &translation,
+		},
+	}, testutil.GetUUID(1))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardService_DeleteCardRemovesOrphanWord(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	symbols, transcription, translation := "九", "jiu", "nine"
+	card, err := svc.CreateCard(context.Background(), dto.CreateCard{
+		GroupID: testutil.GetUUID(3),
+		Word: dto.CreateCardWord{
+			Symbols: &symbols, Transcription: &transcription, Translation: &translation,
+		},
+	}, userID)
+	if err != nil {
+		t.Fatalf("create card: %v", err)
+	}
+	if err := svc.DeleteCard(context.Background(), card.ID, userID); err != nil {
+		t.Fatalf("delete card: %v", err)
+	}
+}
+
+func TestCardService_UpdateCardStatsProgressCaps(t *testing.T) {
+	_, svc, userID := setupFullServices(t)
+	app := testutil.SetupTestApp(t)
+	cardRepo := repository.NewCardRepository(app.Pool())
+	cardID := testutil.GetUUID(1)
+	for i := 0; i < 20; i++ {
+		if err := svc.UpdateCardStats(context.Background(), dto.UpdateCardStats{
+			ID: cardID, Guessed: true,
+		}, userID); err != nil {
+			t.Fatalf("update stats %d: %v", i, err)
+		}
+	}
+	row, err := cardRepo.GetCardByID(context.Background(), cardID)
+	if err != nil {
+		t.Fatalf("get card: %v", err)
+	}
+	if row.Progress != 1 {
+		t.Fatalf("expected progress capped at 1, got %f", row.Progress)
+	}
+}
+
+func TestGroupService_DeleteGroupNotOwned(t *testing.T) {
+	svc, _, _ := setupFullServices(t)
+	err := svc.DeleteGroup(context.Background(), testutil.GetUUID(1), testutil.GetUUID(404))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}
+
+func TestCardService_GetWriteCardsGroupNotOwned(t *testing.T) {
+	_, svc, _ := setupFullServices(t)
+	groupID := testutil.GetUUID(404)
+	_, err := svc.GetWriteCards(context.Background(), dto.GetWriteCard{Count: "2", GroupID: &groupID}, testutil.GetUUID(1))
+	ae, ok := apperrors.IsAppError(err)
+	if !ok || ae.Code != apperrors.EntityNotFoundError {
+		t.Fatalf("expected not found, got %v", err)
+	}
+}

--- a/backend/internal/testutil/testapp.go
+++ b/backend/internal/testutil/testapp.go
@@ -3,6 +3,9 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -34,7 +37,77 @@ func GetUUID(id int) string {
 type TestApp struct {
 	Server  *httptest.Server
 	pool    *pgxpool.Pool
+	tokens  *auth.TokenService
 	Cleanup func()
+}
+
+func (a *TestApp) Pool() *pgxpool.Pool {
+	return a.pool
+}
+
+func (a *TestApp) Tokens() *auth.TokenService {
+	return a.tokens
+}
+
+func (a *TestApp) AuthenticatedRequest(t *testing.T, method, url string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	token, _, err := a.tokens.Issue(auth.UserContext{
+		ID:       GetUUID(1),
+		Username: "slavoyar",
+		Email:    DefaultTestEmail,
+		Provider: "google",
+	})
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: token})
+	return req
+}
+
+func SetupStrictAuthApp(t *testing.T) *TestApp {
+	t.Helper()
+	base := SetupTestApp(t)
+
+	userRepo := repository.NewUserRepository(base.pool)
+	tokenService := auth.NewTokenService("test-jwt-secret", config.DefaultSessionTTL)
+	authenticator := auth.NewSessionAuthenticator(tokenService, userRepo)
+
+	groupRepo := repository.NewGroupRepository(base.pool)
+	wordRepo := repository.NewWordRepository(base.pool)
+	cardRepo := repository.NewCardRepository(base.pool)
+	cloneRepo := repository.NewCloneRepository(base.pool)
+
+	groupService := service.NewGroupService(base.pool, cardRepo, groupRepo, wordRepo)
+	cardService := service.NewCardService(base.pool, cardRepo, groupRepo, wordRepo)
+	wordService := service.NewWordService(wordRepo)
+	googleVerifier := auth.NewGoogleVerifier("test-google-client-id")
+	authService := service.NewAuthService(userRepo, cloneRepo, googleVerifier, tokenService, config.DefaultTemplateEmail)
+
+	cookieConfig := auth.CookieConfig{Secure: false, TTL: config.DefaultSessionTTL}
+	handlers := handler.NewHandlers(
+		groupService,
+		cardService,
+		wordService,
+		authService,
+		userRepo,
+		config.DefaultTemplateEmail,
+		cookieConfig,
+		[]string{"http://localhost:5173"},
+	)
+
+	server := httptest.NewServer(handlers.Router(authenticator, false))
+	t.Cleanup(func() { server.Close() })
+
+	return &TestApp{
+		Server:  server,
+		pool:    base.pool,
+		tokens:  tokenService,
+		Cleanup: func() {},
+	}
 }
 
 func SetupTestApp(t *testing.T) *TestApp {
@@ -60,8 +133,12 @@ func MustInit() *TestApp {
 
 func newTestApp() (*TestApp, error) {
 	ctx := context.Background()
-	dataDir := filepath.Join(os.TempDir(), "chineselaoshi-test-pg")
-	port := uint32(15432)
+	pid := os.Getpid()
+	dataDir := filepath.Join(os.TempDir(), fmt.Sprintf("chineselaoshi-test-pg-%d", pid))
+	port, err := freePort()
+	if err != nil {
+		return nil, err
+	}
 
 	cfg := config.Config{
 		Port:           "3000",
@@ -116,6 +193,7 @@ func newTestApp() (*TestApp, error) {
 	return &TestApp{
 		Server: server,
 		pool:   database.Pool,
+		tokens: tokenService,
 		Cleanup: func() {
 			server.Close()
 			database.Close()
@@ -144,6 +222,29 @@ func seedTestData(ctx context.Context, pool *pgxpool.Pool) error {
 		INSERT INTO "User" (id, username, email, password, provider, provider_subject)
 		VALUES ($1, $2, $3, NULL, $4, $5)
 	`, userID, "slavoyar", DefaultTestEmail, "google", "test-subject-1")
+	if err != nil {
+		return err
+	}
+
+	// Template user demo group for clone-on-login tests.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "Group" (id, name, "wordCount", "userId")
+		VALUES ($1, $2, 1, $3)
+	`, GetUUID(98), "Demo", templateID)
+	if err != nil {
+		return err
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "Word" (id, symbols, transcription, translation)
+		VALUES ($1, $2, $3, $4)
+	`, GetUUID(98), "你", "ni", "you")
+	if err != nil {
+		return err
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "Card" (id, "groupId", "wordId", "updatedAt")
+		VALUES ($1, $2, $3, NOW())
+	`, GetUUID(98), GetUUID(98), GetUUID(98))
 	if err != nil {
 		return err
 	}
@@ -209,4 +310,13 @@ func seedTestData(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 	_, err = pool.Exec(ctx, `UPDATE "Group" SET "wordCount" = 1 WHERE id = $1`, GetUUID(2))
 	return err
+}
+
+func freePort() (uint32, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	return uint32(listener.Addr().(*net.TCPAddr).Port), nil
 }

--- a/backend/scripts/check-coverage.sh
+++ b/backend/scripts/check-coverage.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu
+
+THRESHOLD=80
+PACKAGES=(
+  "./internal/service/..."
+  "./internal/auth/..."
+  "./internal/repository/..."
+)
+
+failed=0
+echo "Coverage summary (minimum ${THRESHOLD}%)"
+echo "----------------------------------------"
+
+for pkg in "${PACKAGES[@]}"; do
+  go test "$pkg" -coverprofile=coverage.out -count=1
+  pct=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}' | tr -d '%')
+  pct_int=${pct%.*}
+  status="OK"
+  if (( pct_int < THRESHOLD )); then
+    status="FAIL"
+    failed=1
+  fi
+  printf "%-40s %6s%%  %s\n" "$pkg" "$pct" "$status"
+done
+
+echo "----------------------------------------"
+if (( failed )); then
+  echo "Coverage check failed: one or more packages below ${THRESHOLD}%"
+  exit 1
+fi
+echo "Coverage check passed"


### PR DESCRIPTION
## Summary
- Add hybrid backend tests: unit tests for auth/utils/middleware/validation, integration tests for handlers/repositories/services against embedded Postgres
- Enforce 80%+ line coverage on \service\, \uth\, and \epository\ packages via \ackend/scripts/check-coverage.sh\ in CI
- Add \GoogleTokenVerifier\ interface seam for mockable Google auth in service tests
- Extend handler tests for auth routes, write-practice, and 401 unauthorized paths with strict session auth

## Coverage (local)
| Package | Coverage |
|---------|----------|
| internal/auth | 82.5% |
| internal/service | 80.0% |
| internal/repository | 80.0% |

## Bugbot review
Three review passes completed; final pass reported no actionable issues.

## Test plan
- [ ] \cd backend && go test ./... -count=1 -p 1\
- [ ] \cd backend && bash scripts/check-coverage.sh\
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)