### PR TITLE
Add group/card store cache with hover prefetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent instructions
+
+## Skills to use
+
+When relevant, **read and follow** these skills before implementing. Do not only mention them — apply their workflows.
+
+### Feature-Sliced Design (`feature-sliced-design`)
+
+Use for frontend architecture: layer placement (`app` / `pages` / `features` / `entities` / `shared`), import direction, public APIs, extractions, and refactors of `frontend/src`.
+
+- Skill path: user skill `feature-sliced-design` (global: `~/.agents/skills/feature-sliced-design`)
+- Prefer pages-first; extract to `features` / `entities` only when reused in 2+ places
+- Import only downward: `app → pages → widgets → features → entities → shared`
+- No cross-imports between slices on the same layer; no `entities → features`
+- This project already uses `widgets/`; do not expand it for new UI — prefer `pages`, `features`, `shared`, or `app`
+- Read skill references only when the specific situation applies (structure, cross-imports, entities, assets, migration)
+
+### Impeccable (`impeccable`)
+
+Use for frontend design and UI work: layout, typography, color, spacing, motion, accessibility, UX copy, polish, and visual quality of pages/components.
+
+- Skill path: user skill `impeccable` (`~/.agents/skills/impeccable` or Cursor skills)
+- Follow its design and anti-pattern guidance when changing UI
+- Respect this app’s existing visual language when editing established screens; do not invent a new theme unless asked
+
+## Frontend stack notes
+
+- Vite + React + React Router + Zustand + axios (not Next.js)
+- Path aliases: `@app`, `@pages`, `@widgets`, `@features`, `@entities`, `@shared`

--- a/frontend/src/app/auth-bootstrap.tsx
+++ b/frontend/src/app/auth-bootstrap.tsx
@@ -1,3 +1,4 @@
+import { useGroupStore } from '@entities/group';
 import { useAuthStore } from '@shared/stores';
 import { useEffect } from 'react';
 
@@ -5,7 +6,10 @@ export const AuthBootstrap = ({ children }: { children: React.ReactNode }) => {
   const [bootstrap, isBootstrapped] = useAuthStore((state) => [state.bootstrap, state.isBootstrapped]);
 
   useEffect(() => {
-    void bootstrap();
+    void (async () => {
+      await bootstrap();
+      void useGroupStore.getState().fetch();
+    })();
   }, [bootstrap]);
 
   if (!isBootstrapped) {

--- a/frontend/src/entities/card/api.ts
+++ b/frontend/src/entities/card/api.ts
@@ -1,4 +1,4 @@
-import { BaseService } from '@shared/api';
+import { BaseService } from '@shared/api/base-service';
 import { Card, CreateCard, GetWriteCard, UpdateCardStats, UpdateCardWord } from '@shared/api/generated';
 import axios from 'axios';
 

--- a/frontend/src/entities/card/model/store.ts
+++ b/frontend/src/entities/card/model/store.ts
@@ -9,26 +9,61 @@ interface State {
 
 interface Action {
   fetch: (id: string) => Promise<void>;
+  prefetch: (id: string) => Promise<void>;
   create: (id: string, data: CreateCard) => Promise<void>;
   delete: (id: string) => Promise<void>;
   updateStats: (id: string, guessed: boolean) => Promise<void>;
   reset: () => void;
 }
 
+const inflightByGroup = new Map<string, Promise<void>>();
+let fetchEpoch = 0;
+
 const useCardStore = create<State & Action>((set, get) => ({
   cardsPerGroup: {},
   loadingGroupIds: {},
   fetch: async (id: string) => {
-    set((state) => ({ loadingGroupIds: { ...state.loadingGroupIds, [id]: true } }));
-    try {
-      const response = await cardService.getList(id);
-      set((state) => ({
-        cardsPerGroup: { ...state.cardsPerGroup, [id]: response },
-        loadingGroupIds: { ...state.loadingGroupIds, [id]: false },
-      }));
-    } catch {
-      set((state) => ({ loadingGroupIds: { ...state.loadingGroupIds, [id]: false } }));
+    if (get().cardsPerGroup[id] !== undefined) {
+      return;
     }
+    const existing = inflightByGroup.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const epoch = fetchEpoch;
+    const promise = (async () => {
+      set((state) => ({ loadingGroupIds: { ...state.loadingGroupIds, [id]: true } }));
+      try {
+        const response = await cardService.getList(id);
+        if (epoch !== fetchEpoch) {
+          return;
+        }
+        set((state) => ({
+          cardsPerGroup: { ...state.cardsPerGroup, [id]: response },
+          loadingGroupIds: { ...state.loadingGroupIds, [id]: false },
+        }));
+      } catch {
+        if (epoch !== fetchEpoch) {
+          return;
+        }
+        set((state) => ({ loadingGroupIds: { ...state.loadingGroupIds, [id]: false } }));
+      } finally {
+        if (epoch === fetchEpoch) {
+          inflightByGroup.delete(id);
+        }
+      }
+    })();
+
+    inflightByGroup.set(id, promise);
+    return promise;
+  },
+  prefetch: async (id: string) => {
+    const { cardsPerGroup, loadingGroupIds } = get();
+    if (cardsPerGroup[id] !== undefined || loadingGroupIds[id]) {
+      return;
+    }
+    await get().fetch(id);
   },
   create: async (id: string, data: CreateCard) => {
     const response = await cardService.post(data);
@@ -53,6 +88,7 @@ const useCardStore = create<State & Action>((set, get) => ({
   },
   updateStats: async (id: string, guessed: boolean) => {
     await cardService.updateCardStats(id, guessed);
+    const epoch = fetchEpoch;
     const { cardsPerGroup } = get();
     const groupId = Object.keys(cardsPerGroup).find((group) =>
       cardsPerGroup[group].some((item) => item.id === id)
@@ -62,6 +98,9 @@ const useCardStore = create<State & Action>((set, get) => ({
     }
     try {
       const response = await cardService.getList(groupId);
+      if (epoch !== fetchEpoch) {
+        return;
+      }
       set((state) => ({
         cardsPerGroup: { ...state.cardsPerGroup, [groupId]: response },
       }));
@@ -70,6 +109,8 @@ const useCardStore = create<State & Action>((set, get) => ({
     }
   },
   reset: () => {
+    fetchEpoch += 1;
+    inflightByGroup.clear();
     set(() => ({ cardsPerGroup: {}, loadingGroupIds: {} }));
   },
 }));

--- a/frontend/src/entities/group/api.ts
+++ b/frontend/src/entities/group/api.ts
@@ -1,4 +1,4 @@
-import { BaseService } from '@shared/api';
+import { BaseService } from '@shared/api/base-service';
 import { Group } from '@shared/api/generated';
 
 const URL = '/api/groups';

--- a/frontend/src/entities/group/model/store.ts
+++ b/frontend/src/entities/group/model/store.ts
@@ -7,6 +7,7 @@ import { DEFAULT_GROUP_ICON, GroupIconKey, setGroupIcon } from '../lib/group-ico
 interface State {
   groups: Group[];
   isLoading: boolean;
+  hasLoaded: boolean;
 }
 
 interface Action {
@@ -19,17 +20,43 @@ interface Action {
   reset: () => void;
 }
 
+let inflightFetch: Promise<void> | null = null;
+let fetchEpoch = 0;
+
 const useGroupStore = create<State & Action>((set, get) => ({
   groups: [],
   isLoading: false,
+  hasLoaded: false,
   fetch: async () => {
-    set(() => ({ isLoading: true }));
-    try {
-      const response = await groupService.getList();
-      set(() => ({ groups: response ?? [], isLoading: false }));
-    } catch {
-      set(() => ({ isLoading: false }));
+    if (get().hasLoaded) {
+      return;
     }
+    if (inflightFetch) {
+      return inflightFetch;
+    }
+
+    const epoch = fetchEpoch;
+    inflightFetch = (async () => {
+      set(() => ({ isLoading: true }));
+      try {
+        const response = await groupService.getList();
+        if (epoch !== fetchEpoch) {
+          return;
+        }
+        set(() => ({ groups: response ?? [], isLoading: false, hasLoaded: true }));
+      } catch {
+        if (epoch !== fetchEpoch) {
+          return;
+        }
+        set(() => ({ isLoading: false }));
+      } finally {
+        if (epoch === fetchEpoch) {
+          inflightFetch = null;
+        }
+      }
+    })();
+
+    return inflightFetch;
   },
   create: async (name: string, iconKey: GroupIconKey = DEFAULT_GROUP_ICON) => {
     const response = await groupService.post({ name });
@@ -71,7 +98,9 @@ const useGroupStore = create<State & Action>((set, get) => ({
     }));
   },
   reset: () => {
-    set(() => ({ groups: [], isLoading: false }));
+    fetchEpoch += 1;
+    inflightFetch = null;
+    set(() => ({ groups: [], isLoading: false, hasLoaded: false }));
   },
 }));
 

--- a/frontend/src/entities/group/ui/group-card.tsx
+++ b/frontend/src/entities/group/ui/group-card.tsx
@@ -1,3 +1,4 @@
+import { useCardStore } from '@entities/card';
 import { getGroupIcon } from '@entities/group/lib/group-icons';
 import { Group } from '@shared/api/generated';
 import { useRequireAuth } from '@shared/hooks';
@@ -16,6 +17,10 @@ export const GroupCard = ({ group, onNavigate, onDelete }: Props) => {
   const Icon = getGroupIcon(group.id);
   const { isDemo } = useRequireAuth();
 
+  const prefetchCards = () => {
+    void useCardStore.getState().prefetch(group.id);
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -32,6 +37,8 @@ export const GroupCard = ({ group, onNavigate, onDelete }: Props) => {
         className='flex h-full cursor-pointer flex-col items-center justify-between rounded-lg border bg-secondary p-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
         onClick={onNavigate}
         onKeyDown={handleKeyDown}
+        onPointerEnter={prefetchCards}
+        onFocus={prefetchCards}
       >
         <div className='flex flex-1 items-center justify-center'>
           <Icon className='h-7 w-7 text-foreground' aria-hidden='true' />

--- a/frontend/src/shared/api/base-service.ts
+++ b/frontend/src/shared/api/base-service.ts
@@ -32,7 +32,9 @@ export class BaseService<Entity, Create = Entity, Update = Entity> {
 
   async get<Response = Entity>(id?: string) {
     return this.request(
-      axios.get<Response, Response>(this.getUrlWithId(id), { cancelToken: this.getCancelToken('get') }),
+      axios.get<Response, Response>(this.getUrlWithId(id), {
+        cancelToken: this.getCancelToken(`get:${id ?? 'all'}`),
+      }),
       { notify: false }
     );
   }
@@ -40,7 +42,7 @@ export class BaseService<Entity, Create = Entity, Update = Entity> {
   async getList<Response = Entity[]>(id?: string) {
     return this.request(
       axios.get<Response, Response>(this.getUrlWithId(id), {
-        cancelToken: this.getCancelToken('getList'),
+        cancelToken: this.getCancelToken(`getList:${id ?? 'all'}`),
       }),
       { notify: false }
     );

--- a/frontend/src/shared/stores/auth-store.ts
+++ b/frontend/src/shared/stores/auth-store.ts
@@ -1,10 +1,12 @@
-import useCardStore from '@entities/card/model/store';
-import useGroupStore from '@entities/group/model/store';
 import { authApi } from '@shared/api/auth';
 import { AuthUser } from '@shared/types/auth';
 import { create } from 'zustand';
 
-const clearSessionCaches = () => {
+const clearSessionCaches = async () => {
+  const [{ default: useCardStore }, { default: useGroupStore }] = await Promise.all([
+    import('@entities/card/model/store'),
+    import('@entities/group/model/store'),
+  ]);
   useCardStore.getState().reset();
   useGroupStore.getState().reset();
 };
@@ -41,7 +43,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
   signInWithGoogle: async (idToken) => {
     const user = await authApi.loginWithGoogle(idToken);
-    clearSessionCaches();
+    await clearSessionCaches();
     set({
       user,
       isDemo: false,
@@ -53,7 +55,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       await authApi.logout();
     } finally {
-      clearSessionCaches();
+      await clearSessionCaches();
       set({
         user: null,
         isDemo: true,


### PR DESCRIPTION
## Summary
- Add in-memory Zustand cache for groups and cards so in-app navigation skips redundant refetches
- Prefetch group cards on tile hover/focus; warm groups fetch after auth bootstrap
- Fix concurrent cancel-token collisions and circular BaseService import via lazy session cache clears
- Add AGENTS.md instructing agents to use Feature-Sliced Design and Impeccable skills

## Test plan
- [ ] Open main: only groups list loads (no card fetches for all groups)
- [ ] Hover a group, then open it: cards render without skeleton when prefetch finished
- [ ] Deep-link to `/groups/:id`: groups+cards load once; navigate away and back without refetch
- [ ] Sign in / sign out: caches clear and data reloads for the new session
- [ ] Confirm no `BaseService before initialization` console error on app start

Made with [Cursor](https://cursor.com)