### PR TITLE
Show tile actions on touch and use destructive delete confirms

### DIFF
--- a/frontend/.impeccable/design.json
+++ b/frontend/.impeccable/design.json
@@ -156,11 +156,6 @@
         "name": "modal-lift",
         "value": "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
         "purpose": "Dialogs and alert dialogs only — never tiles or panels."
-      },
-      {
-        "name": "icon-drop",
-        "value": "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.05))",
-        "purpose": "Delete icon legibility on tile hover."
       }
     ],
     "motion": [
@@ -191,7 +186,7 @@
       "name": "Primary Button",
       "kind": "button",
       "refersTo": "button-primary",
-      "description": "Default committed action — Create, Save, Delete confirm.",
+      "description": "Default constructive committed action — Create, Save.",
       "html": "<button class=\"ds-btn-primary\">Create</button>",
       "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 40px; padding: 8px 16px; border: none; border-radius: 6px; background: #f8fafc; color: #0f172a; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; white-space: nowrap; cursor: pointer; transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), opacity 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-primary:hover { opacity: 0.9; } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #020817, 0 0 0 4px #cbd5e1; } .ds-btn-primary:disabled { opacity: 0.5; pointer-events: none; }"
     },
@@ -238,9 +233,9 @@
       "name": "Tile Delete Button",
       "kind": "button",
       "refersTo": "button-ghost",
-      "description": "Destructive icon revealed on tile hover/focus.",
-      "html": "<button class=\"ds-tile-delete\" aria-label=\"Delete\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.25\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 6h18\"/><path d=\"M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6\"/><path d=\"M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2\"/></svg></button>",
-      "css": ".ds-tile-delete { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: none; border-radius: 6px; background: transparent; color: #ef4444; cursor: pointer; transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1), background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-tile-delete:hover { background: rgba(239, 68, 68, 0.15); color: #f87171; } .ds-tile-delete:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5); color: #f87171; } .ds-tile-delete svg { filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.05)); }"
+      "description": "Quiet secondary action at rest; brightens to red on hover/focus. Always visible when hover is unavailable.",
+      "html": "<button class=\"ds-tile-delete\" aria-label=\"Delete\"><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 6h18\"/><path d=\"M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6\"/><path d=\"M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2\"/></svg></button>",
+      "css": ".ds-tile-delete { position: relative; display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border: none; border-radius: 6px; background: transparent; color: #94a3b8; cursor: pointer; transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1), color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-tile-delete:hover { background: transparent; color: #f87171; } .ds-tile-delete:active { color: #fca5a5; } .ds-tile-delete:focus-visible { outline: none; box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.4); color: #f87171; }"
     },
     {
       "name": "Skeleton Tile",
@@ -291,7 +286,7 @@
       "Do keep Chinese characters at text-2xl or larger on study surfaces; metadata stays at text-xs / text-[10px].",
       "Do use the shared tile grid constants (tileGridClassName, tileItemClassName) for any new collection UI.",
       "Do apply green only through getProgressStyles() semantics for word mastery — border, line, and label together.",
-      "Do reveal destructive actions on hover/focus-within of the parent tile, not persistently visible.",
+      "Do reveal destructive (and other secondary) actions on hover/focus-within of the parent on hover-capable pointers; always show them at full opacity when hover is unavailable.",
       "Do honor prefers-reduced-motion on every transition and skeleton animation.",
       "Do use skeleton tile grids matching final layout while groups or words load.",
       "Do keep primary actions to one per dialog footer; Cancel is always outline variant."
@@ -301,7 +296,7 @@
       "Don't apply generic SaaS dashboard aesthetics to study screens — no hero metrics, no gradient accents, or decorative chart colors on non-analytics views.",
       "Don't clutter interfaces so chrome competes with characters — avoid nested cards, redundant eyebrows, or side-stripe borders on tiles.",
       "Don't use gradient text, glassmorphism, or heavy shadows on tiles and panels.",
-      "Don't show delete buttons at full opacity by default on touch lists — use the reveal pattern.",
+      "Don't gate delete or edit icons on hover alone — touch and other no-hover devices must see them without a pointer hover.",
       "Don't introduce a second accent color family beyond green-for-progress and red-for-destructive.",
       "Don't use display or serif fonts for UI labels, buttons, or data.",
       "Don't gate content visibility on entrance animations — default state must be fully readable without JS-driven reveals."

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -22,7 +22,7 @@ colors:
   progress-mid: "#4ade80"
   progress-high: "#22c55e"
   progress-label: "#16a34a"
-  delete: "#ef4444"
+  delete: "#f87171"
 typography:
   display:
     fontFamily: "ui-sans-serif, system-ui, sans-serif"
@@ -144,7 +144,7 @@ A cool slate-dark palette: near-black blue background, light foreground, and ste
 
 ### Primary
 
-- **Stage Light** (#f8fafc / hsl(210 40% 98%)): Primary buttons, focus-adjacent highlights, and the inverted accent in dark mode. Used for committed actions (Create, Delete confirm) — not decoration.
+- **Stage Light** (#f8fafc / hsl(210 40% 98%)): Primary buttons, focus-adjacent highlights, and the inverted accent in dark mode. Used for constructive committed actions (Create, Save) — not decoration, and not irreversible delete.
 - **Stage Ink** (#0f172a / hsl(222.2 47.4% 11.2%)): Text on primary-filled controls.
 
 ### Secondary (optional; omit if the project has only one accent)
@@ -161,7 +161,7 @@ A cool slate-dark palette: near-black blue background, light foreground, and ste
 - **Soft Ink** (#f8fafc): Primary body text, tile character glyphs, headings.
 - **Supporting Gray** (#94a3b8 / hsl(215 20.2% 65.1%)): Secondary copy — transcriptions, word counts, placeholders, back links. Must remain readable on secondary surfaces (≥4.5:1 against #1e293b).
 - **Focus Ring** (#cbd5e1 / hsl(212.7 26.8% 83.9%)): 2 px focus-visible ring on interactive elements.
-- **Danger Deep** (#7f1d1d / hsl(0 62.8% 30.6%)): Destructive button fill; tile delete uses brighter red (#ef4444) at icon level for scannability.
+- **Danger Deep** (#7f1d1d / hsl(0 62.8% 30.6%)): Destructive button fill. Tile delete rests at Supporting Gray and only brightens to red (#f87171 / red-400) on hover, focus, or press — so always-visible touch chrome does not outrank characters.
 
 ### Named Rules (optional, powerful)
 
@@ -201,7 +201,6 @@ Dialogs and alert dialogs (`DialogContent`, `AlertDialogContent`) use `shadow-lg
 ### Shadow Vocabulary (if applicable)
 
 - **Modal lift** (`box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)` via Tailwind `shadow-lg`): Dialogs and alert dialogs only.
-- **Icon drop** (`filter: drop-shadow(0 1px 1px rgb(0 0 0 / 0.05))`): Delete icon on tile hover for legibility against tile backgrounds.
 
 ### Named Rules (optional)
 
@@ -252,10 +251,11 @@ Not used in current surfaces. Prefer tile metadata text at micro/label sizes ins
 
 - **Grid:** `flex flex-wrap justify-center gap-2` (8px, 10px at sm).
 - **Tile size:** `aspect-square w-24` (96px), `sm:w-[104px]`. Shared via `tileItemClassName`.
-- **Group tile:** Secondary fill, centered Lucide group icon (28px), name at label size, word count at micro. Entire tile is clickable; delete button reveals on hover/focus-within.
-- **Word tile:** Secondary fill, character at display size centered, transcription micro + translation label below, progress bar footer (0.5px lines + centered percent). Top/side border color reflects mastery (see Progress Green).
+- **Group tile:** Secondary fill, centered Lucide group icon (28px), name at label size, word count at micro. Entire tile is clickable; delete button always visible when hover is unavailable, otherwise reveals on hover/focus-within.
+- **Word tile:** Secondary fill; centered stack of character (display size), transcription micro, translation label; progress bar footer (0.5px lines + centered percent). Top/side border color reflects mastery (see Progress Green).
 - **Create tile:** Dashed 2px border, secondary/50 background, Plus icon 24px, micro caption ("Create group" / "Add word"). Hover: solid secondary, primary/50 border tint.
-- **Delete affordance:** Ghost icon button, absolute top-right, red-500, opacity 0 → 100 on group/card hover or focus-within. Hover/active brighten the icon only (red-300 / red-200) with no background fill; focus-visible keeps a soft red ring. 150ms opacity/color transition; `motion-reduce:transition-none`.
+- **Delete affordance:** Ghost icon button, absolute top-right overlay, 36px hit target with the 14px icon hugged into the corner (`items-start justify-end p-1.5`). Rest color is Supporting Gray; hover/active/focus brighten to red-400 / red-300 with no background fill. Always at full opacity when `(hover: none)`; on `(hover: hover)` opacity 0 → 100 on group/card hover or focus-within (`can-hover` Tailwind variant). Soft red focus-visible ring. Does not reserve layout space — word-tile content is a centered character + metadata stack so glyphs keep the stage. 150ms opacity/color transition; `motion-reduce:transition-none`. Same visibility rule for other hover-gated tile actions (e.g. group title edit).
+- **Word tile content:** Centered vertical stack — character (`text-2xl`) then tight pinyin + translation (`gap-1.5` / `space-y-0.5`). Progress bar stays a shrink-0 footer.
 
 ### Dialogs
 
@@ -277,7 +277,7 @@ Not used in current surfaces. Prefer tile metadata text at micro/label sizes ins
 - **Do** keep Chinese characters at `text-2xl` or larger on study surfaces; metadata stays at `text-xs` / `text-[10px]`.
 - **Do** use the shared tile grid constants (`tileGridClassName`, `tileItemClassName`) for any new collection UI.
 - **Do** apply green only through `getProgressStyles()` semantics for word mastery — border, line, and label together.
-- **Do** reveal destructive actions on hover/focus-within of the parent tile, not persistently visible.
+- **Do** reveal destructive (and other secondary) actions on hover/focus-within of the parent on hover-capable pointers; always show them at full opacity when hover is unavailable.
 - **Do** honor `prefers-reduced-motion` on every transition and skeleton animation.
 - **Do** use skeleton tile grids matching final layout while groups or words load.
 - **Do** keep primary actions to one per dialog footer; Cancel is always outline variant.
@@ -288,7 +288,7 @@ Not used in current surfaces. Prefer tile metadata text at micro/label sizes ins
 - **Don't** apply generic SaaS dashboard aesthetics to study screens — no hero metrics, no gradient accents, no decorative chart colors on non-analytics views.
 - **Don't** clutter interfaces so chrome competes with characters — avoid nested cards, redundant eyebrows, or side-stripe borders on tiles.
 - **Don't** use gradient text, glassmorphism, or heavy shadows on tiles and panels.
-- **Don't** show delete buttons at full opacity by default on touch lists — use the reveal pattern.
+- **Don't** gate delete or edit icons on hover alone — touch and other no-hover devices must see them without a pointer hover.
 - **Don't** introduce a second accent color family beyond green-for-progress and red-for-destructive.
 - **Don't** use display or serif fonts for UI labels, buttons, or data.
 - **Don't** gate content visibility on entrance animations — default state must be fully readable without JS-driven reveals.

--- a/frontend/src/entities/card/ui/word-card.tsx
+++ b/frontend/src/entities/card/ui/word-card.tsx
@@ -44,11 +44,9 @@ export const WordCard = ({ card, onDelete }: Props) => {
           )}
           aria-label={`${card.word.symbols}, ${card.word.translation}, ${progressStyles.percentLabel}% progress`}
         >
-          <div className='flex min-h-0 flex-1 flex-col items-center justify-between p-2'>
-            <div className='flex flex-1 items-center justify-center'>
-              <span className='text-2xl font-medium leading-none text-foreground'>{card.word.symbols}</span>
-            </div>
-            <div className='w-full text-center'>
+          <div className='flex min-h-0 flex-1 flex-col items-center justify-center gap-1.5 px-2 py-1.5'>
+            <span className='text-2xl font-medium leading-none text-foreground'>{card.word.symbols}</span>
+            <div className='w-full space-y-0.5 text-center'>
               <p className='truncate text-[10px] leading-tight text-muted-foreground'>
                 {card.word.transcription}
               </p>

--- a/frontend/src/entities/group/ui/group-editable-title.tsx
+++ b/frontend/src/entities/group/ui/group-editable-title.tsx
@@ -107,9 +107,9 @@ export const GroupEditableTitle = ({ groupId, name, className }: Props) => {
           variant='ghost'
           size='icon'
           className={cn(
-            'h-9 w-9 shrink-0 text-muted-foreground opacity-0 transition-opacity duration-150',
+            'h-9 w-9 shrink-0 text-muted-foreground opacity-100 transition-opacity duration-150',
             'hover:bg-accent hover:text-foreground',
-            'group-focus-within/title:opacity-100 group-hover/title:opacity-100',
+            'can-hover:opacity-0 can-hover:group-hover/title:opacity-100 can-hover:group-focus-within/title:opacity-100',
             'focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring',
             'motion-reduce:transition-none'
           )}

--- a/frontend/src/shared/ui/alert-dialog.tsx
+++ b/frontend/src/shared/ui/alert-dialog.tsx
@@ -81,7 +81,11 @@ const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants({ variant: 'destructive' }), className)}
+    {...props}
+  />
 ));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 

--- a/frontend/src/shared/ui/tile-delete-button.tsx
+++ b/frontend/src/shared/ui/tile-delete-button.tsx
@@ -14,17 +14,16 @@ export const TileDeleteButton = ({ onClick, 'aria-label': ariaLabel, className }
     variant='ghost'
     size='icon'
     className={cn(
-      'absolute right-0.5 top-0.5 z-10 h-9 w-9 text-red-500 opacity-0 transition-[opacity,color] duration-150',
-      'hover:bg-transparent hover:text-red-300 active:bg-transparent active:text-red-200',
-      'group-hover/card:opacity-100',
-      'group-focus-within/card:opacity-100',
-      'focus-visible:text-red-300 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500/50',
+      'absolute right-0 top-0 z-10 h-9 w-9 items-start justify-end p-1.5 text-muted-foreground opacity-100 transition-[opacity,color] duration-150',
+      'hover:bg-transparent hover:text-red-400 active:bg-transparent active:text-red-300',
+      'can-hover:opacity-0 can-hover:group-hover/card:opacity-100 can-hover:group-focus-within/card:opacity-100',
+      'focus-visible:text-red-400 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500/40',
       'motion-reduce:transition-none',
       className
     )}
     onClick={onClick}
     aria-label={ariaLabel}
   >
-    <Trash2 className='h-4 w-4 drop-shadow-sm' strokeWidth={2.25} />
+    <Trash2 className='h-3.5 w-3.5' strokeWidth={2} />
   </Button>
 );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -75,5 +75,10 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('tailwindcss-animate'),
+    function ({ addVariant }) {
+      addVariant('can-hover', '@media (hover: hover)');
+    },
+  ],
 };


### PR DESCRIPTION
Reveal hover-gated delete/edit icons when hover is unavailable, quiet their rest color, and style alert confirm as Danger Deep.