### PR TITLE
feat: better production logs for Coolify/Grafana

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -22,22 +22,22 @@ func main() {
 	ctx := context.Background()
 
 	if cfg.JWTSecret == "" {
-		log.Fatal("JWT_SECRET is required")
+		log.Fatal("ERROR JWT_SECRET is required")
 	}
 	if cfg.GoogleClientID == "" {
-		log.Fatal("GOOGLE_CLIENT_ID is required")
+		log.Fatal("ERROR GOOGLE_CLIENT_ID is required")
 	}
 
 	migrationsPath := db.MigrationsPath()
 
 	database, err := db.Bootstrap(ctx, cfg, migrationsPath)
 	if err != nil {
-		log.Fatalf("database bootstrap failed: %v", err)
+		log.Fatalf("ERROR database bootstrap failed: %v", err)
 	}
 	defer database.Close()
 
 	if err := db.EnsureTemplateData(ctx, database.Pool, cfg.TemplateEmail); err != nil {
-		log.Fatalf("seed failed: %v", err)
+		log.Fatalf("ERROR seed failed: %v", err)
 	}
 
 	userRepo := repository.NewUserRepository(database.Pool)
@@ -74,9 +74,9 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("server listening on :%s", cfg.Port)
+		log.Printf("INFO server listening on :%s", cfg.Port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server failed: %v", err)
+			log.Fatalf("ERROR server failed: %v", err)
 		}
 	}()
 
@@ -87,6 +87,6 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		log.Printf("shutdown error: %v", err)
+		log.Printf("ERROR shutdown error: %v", err)
 	}
 }

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -32,7 +32,7 @@ func Bootstrap(ctx context.Context, cfg config.Config, migrationsPath string) (*
 
 		embedded = embeddedpostgres.NewDatabase(embeddedPostgresConfig(cfg))
 
-		log.Printf("starting embedded postgres on :%d", cfg.EmbeddedPGPort)
+		log.Printf("INFO starting embedded postgres on :%d", cfg.EmbeddedPGPort)
 		if err := embedded.Start(); err != nil {
 			return nil, fmt.Errorf("start embedded postgres: %w", err)
 		}

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -34,7 +34,7 @@ func (h *AuthHandler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 
 	user, token, err := h.service.LoginWithGoogle(r.Context(), body.IDToken)
 	if err != nil {
-		log.Printf("google login failed: %v", err)
+		log.Printf("WARN google login failed: %v", err)
 		mapHandlerError(w, err)
 		return
 	}

--- a/backend/internal/handler/validate.go
+++ b/backend/internal/handler/validate.go
@@ -136,6 +136,6 @@ func mapHandlerError(w http.ResponseWriter, err error) {
 		writeJSON(w, ae.StatusCode, ae)
 		return
 	}
-	log.Printf("handler error: %v", err)
+	log.Printf("ERROR handler error: %v", err)
 	writeJSON(w, http.StatusInternalServerError, apperrors.New(apperrors.InternalError))
 }

--- a/backend/internal/middleware/middleware.go
+++ b/backend/internal/middleware/middleware.go
@@ -19,9 +19,14 @@ func Logger(next http.Handler) http.Handler {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		next.ServeHTTP(ww, r)
+		level := "INFO"
+		if ww.Status() >= 500 {
+			level = "ERROR"
+		}
 		log.Printf(
-			"[%s] %s %s %d - %s",
-			time.Now().Format(time.RFC3339),
+			"%s req=%s %s %s %d %s",
+			level,
+			middleware.GetReqID(r.Context()),
 			r.Method,
 			r.URL.String(),
 			ww.Status(),
@@ -58,7 +63,7 @@ func Recoverer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
-				log.Printf("panic: %v", rec)
+				log.Printf("ERROR panic: %v", rec)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 		}()
@@ -82,7 +87,7 @@ func writeError(w http.ResponseWriter, err error) {
 		return
 	}
 
-	log.Printf("internal error: %v", err)
+	log.Printf("ERROR internal error: %v", err)
 	ae := apperrors.New(apperrors.InternalError)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(ae.StatusCode)

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -16,7 +16,7 @@ while [ "$i" -lt 90 ]; do
     break
   fi
   if ! kill -0 "$server_pid" 2>/dev/null; then
-    echo "backend exited before becoming ready" >&2
+    echo "ERROR backend exited before becoming ready" >&2
     wait "$server_pid" || true
     exit 1
   fi

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    access_log off;
+    error_log /dev/stderr warn;
+
     location /api/ {
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- Prefix Go/entrypoint logs with INFO/WARN/ERROR so Coolify and Grafana can filter failures
- Quiet nginx access logs; keep warn-level errors on stderr
- Request logs include chi request ID; 5xx lines are ERROR (401/403 stay INFO)

## Test plan
- [ ] Deploy image and confirm Coolify logs show INFO/ERROR with almost no static-file noise
- [ ] Trigger a 500 and confirm ERROR line appears with req= id
- [ ] Confirm failed Google login logs WARN, not ERROR
- [ ] After Grafana drain setup: Explore `{job="chinese-laoshi"}` and Telegram alert on ERROR|panic
