### PR TITLE
feat: notify ERROR logs to Telegram via an HTTPS relay

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -56,6 +56,9 @@ Copy `backend/.env.example` to `backend/.env` and fill in values. `npm run dev:b
 | `SESSION_TTL_HOURS` | `168` (7 days) | Session cookie lifetime |
 | `ALLOWED_ORIGINS` | non-prod: `http://localhost:5173`, `http://127.0.0.1:5173`; production: *(empty = reject all)* | Origins allowed for **all** `/api` requests (Origin/Referer). Always set explicitly in production. |
 | `NODE_ENV` | *(empty)* | `production` enables secure cookies and disables localhost origin defaults. `test` disables request logging. |
+| `TELEGRAM_BOT_TOKEN` | *(empty)* | Optional. BotFather token. Empty = stderr-only logs (no Telegram). |
+| `TELEGRAM_CHAT_ID` | *(empty)* | Optional. Destination chat. Empty = no Telegram. |
+| `TELEGRAM_RELAY_BASE` | *(empty)* | `https://` base of the Telegram Caddy relay. Required together with token and chat. HTTP is rejected. Do not call `api.telegram.org` from the app host. Telegram Bot API puts the token in the URL path; configure the relay so access logs do not record `/bot*` URLs. |
 
 > **Security:** The Vite dev proxy must target the **local** backend only (`http://localhost:3000`). Do not proxy local frontend traffic to production — production rejects non-allowlisted origins (including localhost).
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Live URL: **https://chineselaoshi.slavoyar.tech**
 - **Pull request** to `production`: lint + frontend build only (no image push).
 - **Push** to `production` (or manual run on that branch): lint + frontend build, then push `ghcr.io/<owner>/chineselaoshi:latest` and `:sha-<commit>`, then Coolify webhook.
 
-Required GitHub Actions secrets: `COOLIFY_WEBHOOK`, `COOLIFY_TOKEN`, `GOOGLE_CLIENT_ID`. Configure application runtime environment in Coolify (not in this workflow). If Coolify should always pull, include `force=true` in the webhook URL secret.
+Required GitHub Actions secrets: `COOLIFY_WEBHOOK`, `COOLIFY_TOKEN`, `GOOGLE_CLIENT_ID`. Configure application runtime environment in Coolify (not in this workflow). For ERROR log Telegram notifies, set `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `TELEGRAM_RELAY_BASE`. If Coolify should always pull, include `force=true` in the webhook URL secret.
 
 ## Contact
 For questions or suggestions, please reach out to slavoyarmc@gmail.com.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,9 @@ JWT_SECRET=
 # NODE_ENV=development
 # COOKIE_SECURE=false
 # SESSION_TTL_HOURS=168
+
+# Optional: ERROR logs POSTed to Telegram via a Caddy relay.
+# All three required (relay base must be https); leave empty locally — no outbound calls.
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
+# TELEGRAM_RELAY_BASE=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/slavo/ChineseLaoshi/backend/internal/applog"
 	"github.com/slavo/ChineseLaoshi/backend/internal/auth"
 	"github.com/slavo/ChineseLaoshi/backend/internal/config"
 	"github.com/slavo/ChineseLaoshi/backend/internal/db"
@@ -19,25 +20,26 @@ import (
 
 func main() {
 	cfg := config.Load()
+	applog.Install(os.Stderr, applog.NewTelegram(cfg.TelegramRelayBase, cfg.TelegramBotToken, cfg.TelegramChatID))
 	ctx := context.Background()
 
 	if cfg.JWTSecret == "" {
-		log.Fatal("ERROR JWT_SECRET is required")
+		applog.Fatal("ERROR JWT_SECRET is required")
 	}
 	if cfg.GoogleClientID == "" {
-		log.Fatal("ERROR GOOGLE_CLIENT_ID is required")
+		applog.Fatal("ERROR GOOGLE_CLIENT_ID is required")
 	}
 
 	migrationsPath := db.MigrationsPath()
 
 	database, err := db.Bootstrap(ctx, cfg, migrationsPath)
 	if err != nil {
-		log.Fatalf("ERROR database bootstrap failed: %v", err)
+		applog.Fatalf("ERROR database bootstrap failed: %v", err)
 	}
 	defer database.Close()
 
 	if err := db.EnsureTemplateData(ctx, database.Pool, cfg.TemplateEmail); err != nil {
-		log.Fatalf("ERROR seed failed: %v", err)
+		applog.Fatalf("ERROR seed failed: %v", err)
 	}
 
 	userRepo := repository.NewUserRepository(database.Pool)
@@ -76,7 +78,7 @@ func main() {
 	go func() {
 		log.Printf("INFO server listening on :%s", cfg.Port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("ERROR server failed: %v", err)
+			applog.Fatalf("ERROR server failed: %v", err)
 		}
 	}()
 
@@ -89,4 +91,5 @@ func main() {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("ERROR shutdown error: %v", err)
 	}
+	applog.Flush()
 }

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -75,9 +76,14 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	ln, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		applog.Fatalf("ERROR server failed: %v", err)
+	}
+	log.Printf("INFO server listening on :%s", cfg.Port)
+	applog.Notify(startedMessage())
 	go func() {
-		log.Printf("INFO server listening on :%s", cfg.Port)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
 			applog.Fatalf("ERROR server failed: %v", err)
 		}
 	}()
@@ -92,4 +98,15 @@ func main() {
 		log.Printf("ERROR shutdown error: %v", err)
 	}
 	applog.Flush()
+}
+
+func startedMessage() string {
+	msg := "Chinese Laoshi server started"
+	if sha := os.Getenv("SOURCE_COMMIT"); sha != "" {
+		if len(sha) > 12 {
+			sha = sha[:12]
+		}
+		msg += " " + sha
+	}
+	return msg
 }

--- a/backend/internal/applog/applog.go
+++ b/backend/internal/applog/applog.go
@@ -1,0 +1,198 @@
+package applog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	maxTextLen     = 3500
+	notifyInterval = 30 * time.Second
+	notifyTimeout  = 5 * time.Second
+)
+
+var (
+	urlRe   = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^\s]+`)
+	queryRe = regexp.MustCompile(`\?[^\s]+`)
+)
+
+func redact(text string) string {
+	text = urlRe.ReplaceAllStringFunc(text, redactURL)
+	return queryRe.ReplaceAllString(text, "")
+}
+
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	if u.User != nil {
+		name := u.User.Username()
+		if _, ok := u.User.Password(); ok {
+			u.User = url.UserPassword(name, "***")
+		}
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+type Notifier interface {
+	Send(ctx context.Context, text string) error
+}
+
+type TelegramNotifier struct {
+	base   string
+	token  string
+	chat   string
+	client *http.Client
+}
+
+func NewTelegram(base, token, chat string) *TelegramNotifier {
+	base = strings.TrimRight(base, "/")
+	if base == "" || token == "" || chat == "" {
+		return nil
+	}
+	u, err := url.Parse(base)
+	if err != nil || !strings.EqualFold(u.Scheme, "https") || u.Host == "" {
+		fmt.Fprintln(os.Stderr, "telegram disabled: TELEGRAM_RELAY_BASE must be https")
+		return nil
+	}
+	return &TelegramNotifier{
+		base:  base,
+		token: token,
+		chat:  chat,
+		client: &http.Client{
+			Timeout: notifyTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+func (n *TelegramNotifier) Send(ctx context.Context, text string) error {
+	if len(text) > maxTextLen {
+		text = text[:maxTextLen]
+	}
+	body, err := json.Marshal(struct {
+		ChatID string `json:"chat_id"`
+		Text   string `json:"text"`
+	}{ChatID: n.chat, Text: text})
+	if err != nil {
+		return err
+	}
+	// Telegram Bot API is /bot<token>/METHOD; the Caddy /bot* relay must not log URLs.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.base+"/bot"+n.token+"/sendMessage", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("telegram status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+type errorWriter struct {
+	stderr io.Writer
+	n      Notifier
+	mu     sync.Mutex
+	last   int64
+	wg     sync.WaitGroup
+}
+
+var installed atomic.Pointer[errorWriter]
+
+func Install(stderr io.Writer, n *TelegramNotifier) {
+	var note Notifier
+	if n != nil {
+		note = n
+	}
+	w := &errorWriter{stderr: stderr, n: note}
+	installed.Store(w)
+	log.SetOutput(w)
+}
+
+func Flush() {
+	if w := installed.Load(); w != nil {
+		w.flush()
+	}
+}
+
+func Fatal(v ...any) {
+	log.Print(v...)
+	Flush()
+	os.Exit(1)
+}
+
+func Fatalf(format string, args ...any) {
+	log.Printf(format, args...)
+	Flush()
+	os.Exit(1)
+}
+
+func isErrorLog(p []byte) bool {
+	msg := p
+	if len(msg) >= 20 && msg[4] == '/' && msg[10] == ' ' {
+		msg = msg[20:]
+	}
+	return bytes.HasPrefix(msg, []byte("ERROR"))
+}
+
+func (w *errorWriter) flush() {
+	w.mu.Lock()
+	w.mu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(notifyTimeout):
+	}
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	n, err := w.stderr.Write(p)
+	if w.n == nil || !isErrorLog(p) {
+		return n, err
+	}
+	w.mu.Lock()
+	now := time.Now().Unix()
+	if now-w.last < int64(notifyInterval.Seconds()) {
+		w.mu.Unlock()
+		return n, err
+	}
+	w.last = now
+	w.wg.Add(1)
+	w.mu.Unlock()
+	msg := string(p)
+	go func() {
+		defer w.wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
+		defer cancel()
+		if sendErr := w.n.Send(ctx, redact(msg)); sendErr != nil {
+			fmt.Fprintln(w.stderr, "telegram notify failed")
+		}
+	}()
+	return n, err
+}

--- a/backend/internal/applog/applog.go
+++ b/backend/internal/applog/applog.go
@@ -137,6 +137,24 @@ func Flush() {
 	}
 }
 
+func Notify(text string) {
+	w := installed.Load()
+	if w == nil || w.n == nil || text == "" {
+		return
+	}
+	w.mu.Lock()
+	w.wg.Add(1)
+	w.mu.Unlock()
+	go func() {
+		defer w.wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
+		defer cancel()
+		if sendErr := w.n.Send(ctx, redact(text)); sendErr != nil {
+			fmt.Fprintln(w.stderr, "telegram notify failed")
+		}
+	}()
+}
+
 func Fatal(v ...any) {
 	log.Print(v...)
 	Flush()

--- a/backend/internal/applog/applog_test.go
+++ b/backend/internal/applog/applog_test.go
@@ -1,0 +1,209 @@
+package applog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type stubNotifier struct {
+	mu  sync.Mutex
+	got []string
+}
+
+func (s *stubNotifier) Send(_ context.Context, text string) error {
+	s.mu.Lock()
+	s.got = append(s.got, text)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *stubNotifier) texts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.got))
+	copy(out, s.got)
+	return out
+}
+
+func TestWriterERRORNotifies(t *testing.T) {
+	stub := &stubNotifier{}
+	var buf bytes.Buffer
+	w := &errorWriter{stderr: &buf, n: stub}
+	if _, err := w.Write([]byte("2026/08/14 00:00:00 ERROR boom\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if !strings.Contains(buf.String(), "ERROR boom") {
+		t.Fatalf("stderr missing line: %q", buf.String())
+	}
+	if got := stub.texts(); len(got) != 1 || !strings.Contains(got[0], "ERROR boom") {
+		t.Fatalf("notify = %#v", got)
+	}
+}
+
+func TestWriterINFODoesNotNotify(t *testing.T) {
+	stub := &stubNotifier{}
+	w := &errorWriter{stderr: io.Discard, n: stub}
+	if _, err := w.Write([]byte("INFO ok\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("INFO req=GET /search?q=ERROR 200\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if got := stub.texts(); len(got) != 0 {
+		t.Fatalf("unexpected notify: %#v", got)
+	}
+}
+
+func TestWriterNilNotifier(t *testing.T) {
+	var buf bytes.Buffer
+	w := &errorWriter{stderr: &buf}
+	if _, err := w.Write([]byte("ERROR boom\n")); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "ERROR boom\n" {
+		t.Fatalf("got %q", buf.String())
+	}
+}
+
+func TestWriterRateLimit(t *testing.T) {
+	stub := &stubNotifier{}
+	w := &errorWriter{stderr: io.Discard, n: stub}
+	if _, err := w.Write([]byte("ERROR one\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if _, err := w.Write([]byte("ERROR two\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if got := stub.texts(); len(got) != 1 {
+		t.Fatalf("notify count = %#v", got)
+	}
+}
+
+type failNotifier struct{}
+
+func (failNotifier) Send(context.Context, string) error { return errors.New("nope") }
+
+func TestWriterFailedNotifyOmitsErrorText(t *testing.T) {
+	var buf bytes.Buffer
+	w := &errorWriter{stderr: &buf, n: failNotifier{}}
+	if _, err := w.Write([]byte("ERROR one\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if strings.Contains(buf.String(), "nope") {
+		t.Fatalf("stderr leaked send error: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "telegram notify failed") {
+		t.Fatalf("stderr missing notify failure: %q", buf.String())
+	}
+}
+
+func TestWriterFailedNotifyStillRateLimits(t *testing.T) {
+	stub := &stubNotifier{}
+	w := &errorWriter{stderr: io.Discard, n: failNotifier{}}
+	if _, err := w.Write([]byte("ERROR one\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	w.n = stub
+	if _, err := w.Write([]byte("ERROR two\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	if got := stub.texts(); len(got) != 0 {
+		t.Fatalf("failed send should still rate-limit, got %#v", got)
+	}
+}
+
+func TestWriterRedactsNotify(t *testing.T) {
+	stub := &stubNotifier{}
+	w := &errorWriter{stderr: io.Discard, n: stub}
+	if _, err := w.Write([]byte("ERROR postgres://u:s3cret@db.example/app?x=1\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.flush()
+	got := stub.texts()
+	if len(got) != 1 || strings.Contains(got[0], "s3cret") || strings.Contains(got[0], "?x=1") {
+		t.Fatalf("notify = %#v", got)
+	}
+}
+
+func TestRedact(t *testing.T) {
+	in := "ERROR database bootstrap failed: postgres://u:s3cret%40x@db.example:5432/app?sslmode=disable"
+	got := redact(in)
+	if strings.Contains(got, "s3cret") || strings.Contains(got, "sslmode") {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestInstallNilNotifier(t *testing.T) {
+	var buf bytes.Buffer
+	Install(&buf, nil)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	log.Print("ERROR boom")
+	if !strings.Contains(buf.String(), "ERROR boom") {
+		t.Fatalf("got %q", buf.String())
+	}
+}
+
+func TestNewTelegramEmpty(t *testing.T) {
+	if NewTelegram("https://relay.example", "", "1") != nil {
+		t.Fatal("expected nil without token")
+	}
+	if NewTelegram("https://relay.example", "tok", "") != nil {
+		t.Fatal("expected nil without chat")
+	}
+	if NewTelegram("", "tok", "1") != nil {
+		t.Fatal("expected nil without relay base")
+	}
+	if NewTelegram("http://relay.example", "tok", "1") != nil {
+		t.Fatal("expected nil for http relay")
+	}
+}
+
+func TestTelegramSend(t *testing.T) {
+	var gotPath, gotBody string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotPath = r.URL.Path
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	n := NewTelegram(srv.URL, "tok", "chat1")
+	if n == nil {
+		t.Fatal("expected notifier")
+	}
+	n.client.Transport = srv.Client().Transport
+	if err := n.Send(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/bottok/sendMessage" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	var payload struct {
+		ChatID string `json:"chat_id"`
+		Text   string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ChatID != "chat1" || payload.Text != "hello" {
+		t.Fatalf("payload = %#v", payload)
+	}
+}

--- a/backend/internal/applog/applog_test.go
+++ b/backend/internal/applog/applog_test.go
@@ -207,3 +207,41 @@ func TestTelegramSend(t *testing.T) {
 		t.Fatalf("payload = %#v", payload)
 	}
 }
+
+func TestNotifySends(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	n := NewTelegram(srv.URL, "tok", "chat1")
+	if n == nil {
+		t.Fatal("expected notifier")
+	}
+	n.client.Transport = srv.Client().Transport
+	Install(io.Discard, n)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	Notify("server started")
+	Flush()
+
+	var payload struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Text != "server started" {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestNotifyNilNoPanic(t *testing.T) {
+	Install(io.Discard, nil)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	Notify("server started")
+	Flush()
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -10,24 +10,27 @@ import (
 )
 
 const (
-	TemplateProvider        = "system"
-	TemplateProviderSubject = "template"
+	TemplateProvider         = "system"
+	TemplateProviderSubject  = "template"
 	DefaultTemplateEmail    = "demo-template@chineselaoshi.local"
 	DefaultSessionTTL       = 7 * 24 * time.Hour
 )
 
 type Config struct {
-	Port             string
-	DBURL            string
-	DataDir          string
-	TemplateEmail    string
-	NodeEnv          string
-	EmbeddedPGPort   uint32
-	GoogleClientID   string
-	JWTSecret        string
-	CookieSecure     bool
-	SessionTTL       time.Duration
-	AllowedOrigins   []string
+	Port              string
+	DBURL             string
+	DataDir           string
+	TemplateEmail     string
+	NodeEnv           string
+	EmbeddedPGPort    uint32
+	GoogleClientID    string
+	JWTSecret         string
+	CookieSecure      bool
+	SessionTTL        time.Duration
+	AllowedOrigins    []string
+	TelegramBotToken  string
+	TelegramChatID    string
+	TelegramRelayBase string
 }
 
 func Load() Config {
@@ -89,16 +92,19 @@ func Load() Config {
 	}
 
 	return Config{
-		Port:           port,
-		DBURL:          os.Getenv("DB_URL"),
-		DataDir:        dataDir,
-		TemplateEmail:  templateEmail,
-		NodeEnv:        nodeEnv,
-		EmbeddedPGPort: embeddedPort,
-		GoogleClientID: os.Getenv("GOOGLE_CLIENT_ID"),
-		JWTSecret:      os.Getenv("JWT_SECRET"),
-		CookieSecure:   cookieSecure,
-		SessionTTL:     sessionTTL,
-		AllowedOrigins: allowedOrigins,
+		Port:              port,
+		DBURL:             os.Getenv("DB_URL"),
+		DataDir:           dataDir,
+		TemplateEmail:     templateEmail,
+		NodeEnv:           nodeEnv,
+		EmbeddedPGPort:    embeddedPort,
+		GoogleClientID:    os.Getenv("GOOGLE_CLIENT_ID"),
+		JWTSecret:         os.Getenv("JWT_SECRET"),
+		CookieSecure:      cookieSecure,
+		SessionTTL:        sessionTTL,
+		AllowedOrigins:    allowedOrigins,
+		TelegramBotToken:  os.Getenv("TELEGRAM_BOT_TOKEN"),
+		TelegramChatID:    os.Getenv("TELEGRAM_CHAT_ID"),
+		TelegramRelayBase: strings.TrimRight(os.Getenv("TELEGRAM_RELAY_BASE"), "/"),
 	}
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -42,3 +42,24 @@ func TestLoadAllowedOriginsExplicit(t *testing.T) {
 		t.Fatalf("unexpected first origin: %q", cfg.AllowedOrigins[0])
 	}
 }
+
+func TestLoadTelegramRelay(t *testing.T) {
+	t.Setenv("TELEGRAM_BOT_TOKEN", "")
+	t.Setenv("TELEGRAM_CHAT_ID", "")
+	t.Setenv("TELEGRAM_RELAY_BASE", "")
+	cfg := Load()
+	if cfg.TelegramRelayBase != "" {
+		t.Fatalf("empty relay = %q", cfg.TelegramRelayBase)
+	}
+
+	t.Setenv("TELEGRAM_RELAY_BASE", "https://relay.example/")
+	t.Setenv("TELEGRAM_BOT_TOKEN", "tok")
+	t.Setenv("TELEGRAM_CHAT_ID", "123")
+	cfg = Load()
+	if cfg.TelegramRelayBase != "https://relay.example" {
+		t.Fatalf("trimmed relay = %q", cfg.TelegramRelayBase)
+	}
+	if cfg.TelegramBotToken != "tok" || cfg.TelegramChatID != "123" {
+		t.Fatalf("token/chat = %q %q", cfg.TelegramBotToken, cfg.TelegramChatID)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,8 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3000}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
+      TELEGRAM_CHAT_ID: ${TELEGRAM_CHAT_ID:-}
+      TELEGRAM_RELAY_BASE: ${TELEGRAM_RELAY_BASE:-}
     volumes:
       - ${PG_DATA_HOST_PATH:-./data}:/app/data


### PR DESCRIPTION
## Summary
- Wrap stdlib `log` so ERROR lines still go to stderr and are also POSTed asynchronously to Telegram through an operator-configured HTTPS Caddy relay.
- Enable only when `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `TELEGRAM_RELAY_BASE` are all set; HTTP relay bases are rejected.
- Rate-limit notifies (30s), redact URL credentials/query strings, flush in-flight sends on fatal/shutdown.

## Test plan
- [x] Local: leave Telegram env unset — app starts; no outbound Telegram calls.
- [x] Coolify: set the three env vars; trigger an ERROR (or a 500) and confirm a Telegram message arrives via the relay.
- [x] Confirm Coolify/container logs still show the same `ERROR …` lines.
- [x] `cd backend && go test ./internal/applog ./internal/config`

Made with [Cursor](https://cursor.com)